### PR TITLE
Sync with upstream changes

### DIFF
--- a/extensions_built_in/advanced_generator/Img2ImgGenerator.py
+++ b/extensions_built_in/advanced_generator/Img2ImgGenerator.py
@@ -12,7 +12,12 @@ from torch.utils.data import DataLoader
 from diffusers import StableDiffusionXLImg2ImgPipeline, PixArtSigmaPipeline
 from tqdm import tqdm
 
-from toolkit.config_modules import ModelConfig, GenerateImageConfig, preprocess_dataset_raw_config, DatasetConfig
+from toolkit.config_modules import (
+    ModelConfig,
+    GenerateImageConfig,
+    preprocess_dataset_raw_config,
+    DatasetConfig,
+)
 from toolkit.data_transfer_object.data_loader import FileItemDTO, DataLoaderBatchDTO
 from toolkit.sampler import get_sampler
 from toolkit.stable_diffusion_model import StableDiffusion
@@ -31,41 +36,40 @@ def flush():
     gc.collect()
 
 
-
-
-
 class GenerateConfig:
 
     def __init__(self, **kwargs):
         self.prompts: List[str]
-        self.sampler = kwargs.get('sampler', 'ddpm')
-        self.neg = kwargs.get('neg', '')
-        self.seed = kwargs.get('seed', -1)
-        self.walk_seed = kwargs.get('walk_seed', False)
-        self.guidance_scale = kwargs.get('guidance_scale', 7)
-        self.sample_steps = kwargs.get('sample_steps', 20)
-        self.guidance_rescale = kwargs.get('guidance_rescale', 0.0)
-        self.ext = kwargs.get('ext', 'png')
-        self.denoise_strength = kwargs.get('denoise_strength', 0.5)
-        self.trigger_word = kwargs.get('trigger_word', None)
+        self.sampler = kwargs.get("sampler", "ddpm")
+        self.neg = kwargs.get("neg", "")
+        self.seed = kwargs.get("seed", -1)
+        self.walk_seed = kwargs.get("walk_seed", False)
+        self.guidance_scale = kwargs.get("guidance_scale", 7)
+        self.sample_steps = kwargs.get("sample_steps", 20)
+        self.guidance_rescale = kwargs.get("guidance_rescale", 0.0)
+        self.ext = kwargs.get("ext", "png")
+        self.denoise_strength = kwargs.get("denoise_strength", 0.5)
+        self.trigger_word = kwargs.get("trigger_word", None)
 
 
 class Img2ImgGenerator(BaseExtensionProcess):
 
     def __init__(self, process_id: int, job, config: OrderedDict):
         super().__init__(process_id, job, config)
-        self.output_folder = self.get_conf('output_folder', required=True)
-        self.copy_inputs_to = self.get_conf('copy_inputs_to', None)
-        self.device = self.get_conf('device', 'cuda')
-        self.model_config = ModelConfig(**self.get_conf('model', required=True))
-        self.generate_config = GenerateConfig(**self.get_conf('generate', required=True))
+        self.output_folder = self.get_conf("output_folder", required=True)
+        self.copy_inputs_to = self.get_conf("copy_inputs_to", None)
+        self.device = self.get_conf("device", "cuda")
+        self.model_config = ModelConfig(**self.get_conf("model", required=True))
+        self.generate_config = GenerateConfig(
+            **self.get_conf("generate", required=True)
+        )
         self.is_latents_cached = True
-        raw_datasets = self.get_conf('datasets', None)
+        raw_datasets = self.get_conf("datasets", None)
         if raw_datasets is not None and len(raw_datasets) > 0:
             raw_datasets = preprocess_dataset_raw_config(raw_datasets)
         self.datasets = None
         self.datasets_reg = None
-        self.dtype = self.get_conf('dtype', 'float16')
+        self.dtype = self.get_conf("dtype", "float16")
         self.torch_dtype = get_torch_dtype(self.dtype)
         self.params = []
         if raw_datasets is not None and len(raw_datasets) > 0:
@@ -128,7 +132,8 @@ class Img2ImgGenerator(BaseExtensionProcess):
             # pipe.unet = torch.compile(pipe.unet, mode="reduce-overhead", fullgraph=True)
             # midas_depth = torch.compile(midas_depth, mode="reduce-overhead", fullgraph=True)
 
-            self.data_loader = get_dataloader_from_datasets(self.datasets, 1, self.sd)
+            loaders = get_dataloader_from_datasets(self.datasets, 1, self.sd)
+            self.data_loader = loaders[0]
 
             num_batches = len(self.data_loader)
             pbar = tqdm(total=num_batches, desc="Generating images")
@@ -137,27 +142,33 @@ class Img2ImgGenerator(BaseExtensionProcess):
             for i, batch in enumerate(self.data_loader):
                 batch: DataLoaderBatchDTO = batch
 
-                gen_seed = seed if seed > 0 else random.randint(0, 2 ** 32 - 1)
+                gen_seed = seed if seed > 0 else random.randint(0, 2**32 - 1)
                 generator = torch.manual_seed(gen_seed)
 
                 file_item: FileItemDTO = batch.file_items[0]
                 img_path = file_item.path
                 img_filename = os.path.basename(img_path)
                 img_filename_no_ext = os.path.splitext(img_filename)[0]
-                img_filename = img_filename_no_ext + '.' + self.generate_config.ext
+                img_filename = img_filename_no_ext + "." + self.generate_config.ext
                 output_path = os.path.join(self.output_folder, img_filename)
-                output_caption_path = os.path.join(self.output_folder, img_filename_no_ext + '.txt')
+                output_caption_path = os.path.join(
+                    self.output_folder, img_filename_no_ext + ".txt"
+                )
 
                 if self.copy_inputs_to is not None:
                     output_inputs_path = os.path.join(self.copy_inputs_to, img_filename)
-                    output_inputs_caption_path = os.path.join(self.copy_inputs_to, img_filename_no_ext + '.txt')
+                    output_inputs_caption_path = os.path.join(
+                        self.copy_inputs_to, img_filename_no_ext + ".txt"
+                    )
                 else:
                     output_inputs_path = None
                     output_inputs_caption_path = None
 
                 caption = batch.get_caption_list()[0]
                 if self.generate_config.trigger_word is not None:
-                    caption = caption.replace('[trigger]', self.generate_config.trigger_word)
+                    caption = caption.replace(
+                        "[trigger]", self.generate_config.trigger_word
+                    )
 
                 img: torch.Tensor = batch.tensor.clone()
                 image = self.to_pil(img)
@@ -168,13 +179,18 @@ class Img2ImgGenerator(BaseExtensionProcess):
 
                     # Encode the full image once
                     encoded_image = pipe.vae.encode(
-                        pipe.image_processor.preprocess(image).to(device=pipe.device, dtype=pipe.dtype))
+                        pipe.image_processor.preprocess(image).to(
+                            device=pipe.device, dtype=pipe.dtype
+                        )
+                    )
                     if hasattr(encoded_image, "latent_dist"):
                         latents = encoded_image.latent_dist.sample(generator)
                     elif hasattr(encoded_image, "latents"):
                         latents = encoded_image.latents
                     else:
-                        raise AttributeError("Could not access latents of provided encoder_output")
+                        raise AttributeError(
+                            "Could not access latents of provided encoder_output"
+                        )
                     latents = pipe.vae.config.scaling_factor * latents
 
                     # latents = self.sd.encode_images(img)
@@ -190,15 +206,23 @@ class Img2ImgGenerator(BaseExtensionProcess):
                     batch_size = 1
                     num_images_per_prompt = 1
 
-                    shape = (batch_size, pipe.transformer.config.in_channels, image.height // pipe.vae_scale_factor,
-                             image.width // pipe.vae_scale_factor)
-                    noise = randn_tensor(shape, generator=generator, device=pipe.device, dtype=pipe.dtype)
+                    shape = (
+                        batch_size,
+                        pipe.transformer.config.in_channels,
+                        image.height // pipe.vae_scale_factor,
+                        image.width // pipe.vae_scale_factor,
+                    )
+                    noise = randn_tensor(
+                        shape, generator=generator, device=pipe.device, dtype=pipe.dtype
+                    )
 
                     # noise = torch.randn_like(latents, device=device, dtype=self.torch_dtype)
                     num_inference_steps = self.generate_config.sample_steps
                     strength = self.generate_config.denoise_strength
                     # Get timesteps
-                    init_timestep = min(int(num_inference_steps * strength), num_inference_steps)
+                    init_timestep = min(
+                        int(num_inference_steps * strength), num_inference_steps
+                    )
                     t_start = max(num_inference_steps - init_timestep, 0)
                     pipe.scheduler.set_timesteps(num_inference_steps, device="cpu")
                     timesteps = pipe.scheduler.timesteps[t_start:]
@@ -217,7 +241,7 @@ class Img2ImgGenerator(BaseExtensionProcess):
                         guidance_scale=self.generate_config.guidance_scale,
                         # strength=self.generate_config.denoise_strength,
                         use_resolution_binning=False,
-                        output_type="np"
+                        output_type="np",
                     ).images[0]
                     gen_images = (gen_images * 255).clip(0, 255).astype(np.uint8)
                     gen_images = Image.fromarray(gen_images)
@@ -236,13 +260,13 @@ class Img2ImgGenerator(BaseExtensionProcess):
                 gen_images.save(output_path)
 
                 # save caption
-                with open(output_caption_path, 'w') as f:
+                with open(output_caption_path, "w") as f:
                     f.write(caption)
 
                 if output_inputs_path is not None:
                     os.makedirs(os.path.dirname(output_inputs_path), exist_ok=True)
                     image.save(output_inputs_path)
-                    with open(output_inputs_caption_path, 'w') as f:
+                    with open(output_inputs_caption_path, "w") as f:
                         f.write(caption)
 
                 pbar.update(1)

--- a/extensions_built_in/sd_trainer/SDTrainer.py
+++ b/extensions_built_in/sd_trainer/SDTrainer.py
@@ -24,8 +24,13 @@ from toolkit.print import print_acc
 from toolkit.prompt_utils import PromptEmbeds, concat_prompt_embeds
 from toolkit.reference_adapter import ReferenceAdapter
 from toolkit.stable_diffusion_model import StableDiffusion, BlankNetwork
-from toolkit.train_tools import get_torch_dtype, apply_snr_weight, add_all_snr_to_noise_scheduler, \
-    apply_learnable_snr_gos, LearnableSNRGamma
+from toolkit.train_tools import (
+    get_torch_dtype,
+    apply_snr_weight,
+    add_all_snr_to_noise_scheduler,
+    apply_learnable_snr_gos,
+    LearnableSNRGamma,
+)
 import gc
 import torch
 from jobs.process import BaseSDTrainProcess
@@ -33,7 +38,10 @@ from torchvision import transforms
 from diffusers import EMAModel
 import math
 from toolkit.train_tools import precondition_model_outputs_flow_match
-from toolkit.models.diffusion_feature_extraction import DiffusionFeatureExtractor, load_dfe
+from toolkit.models.diffusion_feature_extraction import (
+    DiffusionFeatureExtractor,
+    load_dfe,
+)
 from toolkit.util.wavelet_loss import wavelet_loss
 import torch.nn.functional as F
 from toolkit.models.flux import convert_flux_to_mean_flow
@@ -44,16 +52,18 @@ def flush():
     gc.collect()
 
 
-adapter_transforms = transforms.Compose([
-    transforms.ToTensor(),
-])
+adapter_transforms = transforms.Compose(
+    [
+        transforms.ToTensor(),
+    ]
+)
 
 
 class SDTrainer(BaseSDTrainProcess):
 
     def __init__(self, process_id: int, job, config: OrderedDict, **kwargs):
         super().__init__(process_id, job, config, **kwargs)
-        self.assistant_adapter: Union['T2IAdapter', 'ControlNetModel', None]
+        self.assistant_adapter: Union["T2IAdapter", "ControlNetModel", None]
         self.do_prior_prediction = False
         self.do_long_prompts = False
         self.do_guided_loss = False
@@ -64,7 +74,9 @@ class SDTrainer(BaseSDTrainProcess):
         self.batch_negative_prompt: Union[List[str], None] = None
         self.cfm_cache = None
 
-        self.is_bfloat = self.train_config.dtype == "bfloat16" or self.train_config.dtype == "bf16"
+        self.is_bfloat = (
+            self.train_config.dtype == "bfloat16" or self.train_config.dtype == "bf16"
+        )
 
         self.do_grad_scale = True
         if self.is_fine_tuning and self.is_bfloat:
@@ -83,20 +95,25 @@ class SDTrainer(BaseSDTrainProcess):
         self.cached_blank_embeds: Optional[PromptEmbeds] = None
         self.cached_trigger_embeds: Optional[PromptEmbeds] = None
         self.diff_output_preservation_embeds: Optional[PromptEmbeds] = None
-        
+
         self.dfe: Optional[DiffusionFeatureExtractor] = None
-        
+
         if self.train_config.diff_output_preservation:
             if self.trigger_word is None:
-                raise ValueError("diff_output_preservation requires a trigger_word to be set")
+                raise ValueError(
+                    "diff_output_preservation requires a trigger_word to be set"
+                )
             if self.network_config is None:
-                raise ValueError("diff_output_preservation requires a network to be set")
+                raise ValueError(
+                    "diff_output_preservation requires a network to be set"
+                )
             if self.train_config.train_text_encoder:
-                raise ValueError("diff_output_preservation is not supported with train_text_encoder")
-            
+                raise ValueError(
+                    "diff_output_preservation is not supported with train_text_encoder"
+                )
+
             # always do a prior prediction when doing diff output preservation
             self.do_prior_prediction = True
-
 
     def before_model_load(self):
         pass
@@ -117,19 +134,27 @@ class SDTrainer(BaseSDTrainProcess):
                     adapter_path, torch_dtype=get_torch_dtype(self.train_config.dtype)
                 ).to(self.device_torch, dtype=get_torch_dtype(self.train_config.dtype))
             else:
-                raise ValueError(f"Unknown adapter assist type {self.train_config.adapter_assist_type}")
+                raise ValueError(
+                    f"Unknown adapter assist type {self.train_config.adapter_assist_type}"
+                )
 
             self.assistant_adapter.eval()
             self.assistant_adapter.requires_grad_(False)
             flush()
         if self.train_config.train_turbo and self.train_config.show_turbo_outputs:
             if self.model_config.is_xl:
-                self.taesd = AutoencoderTiny.from_pretrained("madebyollin/taesdxl",
-                                                             torch_dtype=get_torch_dtype(self.train_config.dtype))
+                self.taesd = AutoencoderTiny.from_pretrained(
+                    "madebyollin/taesdxl",
+                    torch_dtype=get_torch_dtype(self.train_config.dtype),
+                )
             else:
-                self.taesd = AutoencoderTiny.from_pretrained("madebyollin/taesd",
-                                                             torch_dtype=get_torch_dtype(self.train_config.dtype))
-            self.taesd.to(dtype=get_torch_dtype(self.train_config.dtype), device=self.device_torch)
+                self.taesd = AutoencoderTiny.from_pretrained(
+                    "madebyollin/taesd",
+                    torch_dtype=get_torch_dtype(self.train_config.dtype),
+                )
+            self.taesd.to(
+                dtype=get_torch_dtype(self.train_config.dtype), device=self.device_torch
+            )
             self.taesd.eval()
             self.taesd.requires_grad_(False)
 
@@ -138,7 +163,7 @@ class SDTrainer(BaseSDTrainProcess):
         if self.train_config.timestep_type == "mean_flow":
             # todo handle non flux models
             convert_flux_to_mean_flow(self.sd.transformer)
-        
+
         if self.train_config.do_prior_divergence:
             self.do_prior_prediction = True
         # move vae to device if we did not cache latents
@@ -147,7 +172,7 @@ class SDTrainer(BaseSDTrainProcess):
             self.sd.vae.to(self.device_torch)
         else:
             # offload it. Already cached
-            self.sd.vae.to('cpu')
+            self.sd.vae.to("cpu")
             flush()
         add_all_snr_to_noise_scheduler(self.sd.noise_scheduler, self.device_torch)
         if self.adapter is not None:
@@ -155,26 +180,37 @@ class SDTrainer(BaseSDTrainProcess):
 
             # check if we have regs and using adapter and caching clip embeddings
             has_reg = self.datasets_reg is not None and len(self.datasets_reg) > 0
-            is_caching_clip_embeddings = self.datasets is not None and any([self.datasets[i].cache_clip_vision_to_disk for i in range(len(self.datasets))])
+            is_caching_clip_embeddings = self.datasets is not None and any(
+                [
+                    self.datasets[i].cache_clip_vision_to_disk
+                    for i in range(len(self.datasets))
+                ]
+            )
 
             if has_reg and is_caching_clip_embeddings:
                 # we need a list of unconditional clip image embeds from other datasets to handle regs
                 unconditional_clip_image_embeds = []
                 datasets = get_dataloader_datasets(self.data_loader)
                 for i in range(len(datasets)):
-                    unconditional_clip_image_embeds += datasets[i].clip_vision_unconditional_cache
+                    unconditional_clip_image_embeds += datasets[
+                        i
+                    ].clip_vision_unconditional_cache
 
                 if len(unconditional_clip_image_embeds) == 0:
-                    raise ValueError("No unconditional clip image embeds found. This should not happen")
+                    raise ValueError(
+                        "No unconditional clip image embeds found. This should not happen"
+                    )
 
                 self._clip_image_embeds_unconditional = unconditional_clip_image_embeds
 
         if self.train_config.negative_prompt is not None:
             if os.path.exists(self.train_config.negative_prompt):
-                with open(self.train_config.negative_prompt, 'r') as f:
+                with open(self.train_config.negative_prompt, "r") as f:
                     self.negative_prompt_pool = f.readlines()
                     # remove empty
-                    self.negative_prompt_pool = [x.strip() for x in self.negative_prompt_pool if x.strip() != ""]
+                    self.negative_prompt_pool = [
+                        x.strip() for x in self.negative_prompt_pool if x.strip() != ""
+                    ]
             else:
                 # single prompt
                 self.negative_prompt_pool = [self.train_config.negative_prompt]
@@ -183,43 +219,57 @@ class SDTrainer(BaseSDTrainProcess):
         if self.train_config.unload_text_encoder:
             with torch.no_grad():
                 if self.train_config.train_text_encoder:
-                    raise ValueError("Cannot unload text encoder if training text encoder")
+                    raise ValueError(
+                        "Cannot unload text encoder if training text encoder"
+                    )
                 # cache embeddings
 
                 print_acc("\n***** UNLOADING TEXT ENCODER *****")
-                print_acc("This will train only with a blank prompt or trigger word, if set")
-                print_acc("If this is not what you want, remove the unload_text_encoder flag")
+                print_acc(
+                    "This will train only with a blank prompt or trigger word, if set"
+                )
+                print_acc(
+                    "If this is not what you want, remove the unload_text_encoder flag"
+                )
                 print_acc("***********************************")
                 print_acc("")
                 self.sd.text_encoder_to(self.device_torch)
                 self.cached_blank_embeds = self.sd.encode_prompt("")
                 if self.trigger_word is not None:
-                    self.cached_trigger_embeds = self.sd.encode_prompt(self.trigger_word)
+                    self.cached_trigger_embeds = self.sd.encode_prompt(
+                        self.trigger_word
+                    )
                 if self.train_config.diff_output_preservation:
-                    self.diff_output_preservation_embeds = self.sd.encode_prompt(self.train_config.diff_output_preservation_class)
+                    self.diff_output_preservation_embeds = self.sd.encode_prompt(
+                        self.train_config.diff_output_preservation_class
+                    )
 
                 # move back to cpu
-                self.sd.text_encoder_to('cpu')
+                self.sd.text_encoder_to("cpu")
                 flush()
-        
+
         if self.train_config.diffusion_feature_extractor_path is not None:
             vae = self.sd.vae
             # if not (self.model_config.arch in ["flux"]) or self.sd.vae.__class__.__name__ == "AutoencoderPixelMixer":
             #     vae = self.sd.vae
-            self.dfe = load_dfe(self.train_config.diffusion_feature_extractor_path, vae=vae)
+            self.dfe = load_dfe(
+                self.train_config.diffusion_feature_extractor_path, vae=vae
+            )
             self.dfe.to(self.device_torch)
-            if hasattr(self.dfe, 'vision_encoder') and self.train_config.gradient_checkpointing:
+            if (
+                hasattr(self.dfe, "vision_encoder")
+                and self.train_config.gradient_checkpointing
+            ):
                 # must be set to train for gradient checkpointing to work
                 self.dfe.vision_encoder.train()
                 self.dfe.vision_encoder.gradient_checkpointing = True
             else:
                 self.dfe.eval()
-                
+
             # enable gradient checkpointing on the vae
             if vae is not None and self.train_config.gradient_checkpointing:
                 vae.enable_gradient_checkpointing()
                 vae.train()
-
 
     def process_output_for_turbo(self, pred, noisy_latents, timesteps, noise, batch):
         # to process turbo learning, we make one big step from our current timestep to the end
@@ -237,17 +287,14 @@ class SDTrainer(BaseSDTrainProcess):
             # set the timesteps to 1000 so we can capture them to calculate the sigmas
             self.sd.noise_scheduler.set_timesteps(
                 self.sd.noise_scheduler.config.num_train_timesteps,
-                device=self.device_torch
+                device=self.device_torch,
             )
             train_timesteps = self.sd.noise_scheduler.timesteps.clone().detach()
 
             train_sigmas = self.sd.noise_scheduler.sigmas.clone().detach()
 
             # set the scheduler to one timestep, we build the step and sigmas for each item in batch for the partial step
-            self.sd.noise_scheduler.set_timesteps(
-                1,
-                device=self.device_torch
-            )
+            self.sd.noise_scheduler.set_timesteps(1, device=self.device_torch)
 
         denoised_pred_chunks = []
         target_pred_chunks = []
@@ -259,13 +306,19 @@ class SDTrainer(BaseSDTrainProcess):
             latents_item = latent_chunks[i]
             noise_item = noise_chunks[i]
             with torch.no_grad():
-                timestep_idx = [(train_timesteps == t).nonzero().item() for t in timesteps_item][0]
+                timestep_idx = [
+                    (train_timesteps == t).nonzero().item() for t in timesteps_item
+                ][0]
                 single_step_timestep_schedule = [timesteps_item.squeeze().item()]
                 # extract the sigma idx for our midpoint timestep
-                sigmas = train_sigmas[timestep_idx:timestep_idx + 1].to(self.device_torch)
+                sigmas = train_sigmas[timestep_idx : timestep_idx + 1].to(
+                    self.device_torch
+                )
 
                 end_sigma_idx = random.randint(timestep_idx, len(train_sigmas) - 1)
-                end_sigma = train_sigmas[end_sigma_idx:end_sigma_idx + 1].to(self.device_torch)
+                end_sigma = train_sigmas[end_sigma_idx : end_sigma_idx + 1].to(
+                    self.device_torch
+                )
 
                 # add noise to our target
 
@@ -281,11 +334,17 @@ class SDTrainer(BaseSDTrainProcess):
                 self.sd.noise_scheduler._step_index = None
 
             denoised_latent = self.sd.noise_scheduler.step(
-                pred_item, timesteps_item, noisy_latents_item.detach(), return_dict=False
+                pred_item,
+                timesteps_item,
+                noisy_latents_item.detach(),
+                return_dict=False,
             )[0]
 
-            residual_noise = (noise_item * end_sigma.flatten()).detach().to(self.device_torch, dtype=get_torch_dtype(
-                self.train_config.dtype))
+            residual_noise = (
+                (noise_item * end_sigma.flatten())
+                .detach()
+                .to(self.device_torch, dtype=get_torch_dtype(self.train_config.dtype))
+            )
             # remove the residual noise from the denoised latents. Output should be a clean prediction (theoretically)
             denoised_latent = denoised_latent - residual_noise
 
@@ -294,11 +353,10 @@ class SDTrainer(BaseSDTrainProcess):
         denoised_latents = torch.cat(denoised_pred_chunks, dim=0)
         # set the scheduler back to the original timesteps
         self.sd.noise_scheduler.set_timesteps(
-            self.sd.noise_scheduler.config.num_train_timesteps,
-            device=self.device_torch
+            self.sd.noise_scheduler.config.num_train_timesteps, device=self.device_torch
         )
 
-        output = denoised_latents / self.sd.vae.config['scaling_factor']
+        output = denoised_latents / self.sd.vae.config["scaling_factor"]
         output = self.sd.vae.decode(output).sample
 
         if self.train_config.show_turbo_outputs:
@@ -310,19 +368,21 @@ class SDTrainer(BaseSDTrainProcess):
         # you can do mse against the two here  or run the denoised through the vae for pixel space loss against the
         # input tensor images.
 
-        return output, batch.tensor.to(self.device_torch, dtype=get_torch_dtype(self.train_config.dtype))
+        return output, batch.tensor.to(
+            self.device_torch, dtype=get_torch_dtype(self.train_config.dtype)
+        )
 
     # you can expand these in a child class to make customization easier
     def calculate_loss(
-            self,
-            noise_pred: torch.Tensor,
-            noise: torch.Tensor,
-            noisy_latents: torch.Tensor,
-            timesteps: torch.Tensor,
-            batch: 'DataLoaderBatchDTO',
-            mask_multiplier: Union[torch.Tensor, float] = 1.0,
-            prior_pred: Union[torch.Tensor, None] = None,
-            **kwargs
+        self,
+        noise_pred: torch.Tensor,
+        noise: torch.Tensor,
+        noisy_latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        batch: "DataLoaderBatchDTO",
+        mask_multiplier: Union[torch.Tensor, float] = 1.0,
+        prior_pred: Union[torch.Tensor, None] = None,
+        **kwargs,
     ):
         loss_target = self.train_config.loss_target
         is_reg = any(batch.get_is_reg_list())
@@ -335,12 +395,18 @@ class SDTrainer(BaseSDTrainProcess):
         has_mask = batch.mask_tensor is not None
 
         with torch.no_grad():
-            loss_multiplier = torch.tensor(batch.loss_multiplier_list).to(self.device_torch, dtype=torch.float32)
+            loss_multiplier = torch.tensor(batch.loss_multiplier_list).to(
+                self.device_torch, dtype=torch.float32
+            )
 
         if self.train_config.match_noise_norm:
             # match the norm of the noise
-            noise_norm = torch.linalg.vector_norm(noise, ord=2, dim=(1, 2, 3), keepdim=True)
-            noise_pred_norm = torch.linalg.vector_norm(noise_pred, ord=2, dim=(1, 2, 3), keepdim=True)
+            noise_norm = torch.linalg.vector_norm(
+                noise, ord=2, dim=(1, 2, 3), keepdim=True
+            )
+            noise_pred_norm = torch.linalg.vector_norm(
+                noise_pred, ord=2, dim=(1, 2, 3), keepdim=True
+            )
             noise_pred = noise_pred * (noise_norm / noise_pred_norm)
 
         if self.train_config.pred_scaler != 1.0:
@@ -351,21 +417,29 @@ class SDTrainer(BaseSDTrainProcess):
         if self.train_config.target_noise_multiplier != 1.0:
             noise = noise * self.train_config.target_noise_multiplier
 
-        if self.train_config.correct_pred_norm or (self.train_config.inverted_mask_prior and prior_pred is not None and has_mask):
+        if self.train_config.correct_pred_norm or (
+            self.train_config.inverted_mask_prior
+            and prior_pred is not None
+            and has_mask
+        ):
             if self.train_config.correct_pred_norm and not is_reg:
                 with torch.no_grad():
                     # this only works if doing a prior pred
                     if prior_pred is not None:
-                        prior_mean = prior_pred.mean([2,3], keepdim=True)
-                        prior_std = prior_pred.std([2,3], keepdim=True)
-                        noise_mean = noise_pred.mean([2,3], keepdim=True)
-                        noise_std = noise_pred.std([2,3], keepdim=True)
+                        prior_mean = prior_pred.mean([2, 3], keepdim=True)
+                        prior_std = prior_pred.std([2, 3], keepdim=True)
+                        noise_mean = noise_pred.mean([2, 3], keepdim=True)
+                        noise_std = noise_pred.std([2, 3], keepdim=True)
 
                         mean_adjust = prior_mean - noise_mean
                         std_adjust = prior_std - noise_std
 
-                        mean_adjust = mean_adjust * self.train_config.correct_pred_norm_multiplier
-                        std_adjust = std_adjust * self.train_config.correct_pred_norm_multiplier
+                        mean_adjust = (
+                            mean_adjust * self.train_config.correct_pred_norm_multiplier
+                        )
+                        std_adjust = (
+                            std_adjust * self.train_config.correct_pred_norm_multiplier
+                        )
 
                         target_mean = noise_mean + mean_adjust
                         target_std = noise_std + std_adjust
@@ -376,19 +450,31 @@ class SDTrainer(BaseSDTrainProcess):
                         noise = noise * (target_std + eps) + target_mean
                         noise = noise.detach()
 
-            if self.train_config.inverted_mask_prior and prior_pred is not None and has_mask:
+            if (
+                self.train_config.inverted_mask_prior
+                and prior_pred is not None
+                and has_mask
+            ):
                 assert not self.train_config.train_turbo
                 with torch.no_grad():
                     prior_mask = batch.mask_tensor.to(self.device_torch, dtype=dtype)
                     # resize to size of noise_pred
-                    prior_mask = torch.nn.functional.interpolate(prior_mask, size=(noise_pred.shape[2], noise_pred.shape[3]), mode='bicubic')
+                    prior_mask = torch.nn.functional.interpolate(
+                        prior_mask,
+                        size=(noise_pred.shape[2], noise_pred.shape[3]),
+                        mode="bicubic",
+                    )
                     # stack first channel to match channels of noise_pred
-                    prior_mask = torch.cat([prior_mask[:1]] * noise_pred.shape[1], dim=1)
+                    prior_mask = torch.cat(
+                        [prior_mask[:1]] * noise_pred.shape[1], dim=1
+                    )
 
                     prior_mask_multiplier = 1.0 - prior_mask
-                    
+
                     # scale so it is a mean of 1
-                    prior_mask_multiplier = prior_mask_multiplier / prior_mask_multiplier.mean()
+                    prior_mask_multiplier = (
+                        prior_mask_multiplier / prior_mask_multiplier.mean()
+                    )
                 if self.sd.is_flow_matching:
                     target = (noise - batch.latents).detach()
                 else:
@@ -397,17 +483,19 @@ class SDTrainer(BaseSDTrainProcess):
             assert not self.train_config.train_turbo
             # matching adapter prediction
             target = prior_pred
-        elif self.sd.prediction_type == 'v_prediction':
+        elif self.sd.prediction_type == "v_prediction":
             # v-parameterization training
-            target = self.sd.noise_scheduler.get_velocity(batch.tensor, noise, timesteps)
-        
-        elif hasattr(self.sd, 'get_loss_target'):
+            target = self.sd.noise_scheduler.get_velocity(
+                batch.tensor, noise, timesteps
+            )
+
+        elif hasattr(self.sd, "get_loss_target"):
             target = self.sd.get_loss_target(
-                noise=noise, 
-                batch=batch, 
+                noise=noise,
+                batch=batch,
                 timesteps=timesteps,
             ).detach()
-            
+
         elif self.sd.is_flow_matching:
             # forward ODE
             target = (noise - batch.latents).detach()
@@ -415,33 +503,51 @@ class SDTrainer(BaseSDTrainProcess):
             # target = (batch.latents - noise).detach()
         else:
             target = noise
-            
+
         if self.dfe is not None:
             if self.dfe.version == 1:
                 # do diffusion feature extraction on target
                 with torch.no_grad():
                     rectified_flow_target = noise.float() - batch.latents.float()
-                    target_features = self.dfe(torch.cat([rectified_flow_target, noise.float()], dim=1))
-                
+                    target_features = self.dfe(
+                        torch.cat([rectified_flow_target, noise.float()], dim=1)
+                    )
+
                 # do diffusion feature extraction on prediction
-                pred_features = self.dfe(torch.cat([noise_pred.float(), noise.float()], dim=1))
-                additional_loss += torch.nn.functional.mse_loss(pred_features, target_features, reduction="mean") * \
-                    self.train_config.diffusion_feature_extractor_weight
+                pred_features = self.dfe(
+                    torch.cat([noise_pred.float(), noise.float()], dim=1)
+                )
+                additional_loss += (
+                    torch.nn.functional.mse_loss(
+                        pred_features, target_features, reduction="mean"
+                    )
+                    * self.train_config.diffusion_feature_extractor_weight
+                )
             elif self.dfe.version == 2:
                 # version 2
                 # do diffusion feature extraction on target
                 with torch.no_grad():
                     rectified_flow_target = noise.float() - batch.latents.float()
-                    target_feature_list = self.dfe(torch.cat([rectified_flow_target, noise.float()], dim=1))
-                
+                    target_feature_list = self.dfe(
+                        torch.cat([rectified_flow_target, noise.float()], dim=1)
+                    )
+
                 # do diffusion feature extraction on prediction
-                pred_feature_list = self.dfe(torch.cat([noise_pred.float(), noise.float()], dim=1))
-                
+                pred_feature_list = self.dfe(
+                    torch.cat([noise_pred.float(), noise.float()], dim=1)
+                )
+
                 dfe_loss = 0.0
                 for i in range(len(target_feature_list)):
-                    dfe_loss += torch.nn.functional.mse_loss(pred_feature_list[i], target_feature_list[i], reduction="mean")
-                
-                additional_loss += dfe_loss * self.train_config.diffusion_feature_extractor_weight * 100.0
+                    dfe_loss += torch.nn.functional.mse_loss(
+                        pred_feature_list[i], target_feature_list[i], reduction="mean"
+                    )
+
+                additional_loss += (
+                    dfe_loss
+                    * self.train_config.diffusion_feature_extractor_weight
+                    * 100.0
+                )
             elif self.dfe.version == 3 or self.dfe.version == 4:
                 dfe_loss = self.dfe(
                     noise=noise,
@@ -449,24 +555,29 @@ class SDTrainer(BaseSDTrainProcess):
                     noisy_latents=noisy_latents,
                     timesteps=timesteps,
                     batch=batch,
-                    scheduler=self.sd.noise_scheduler
+                    scheduler=self.sd.noise_scheduler,
                 )
-                additional_loss += dfe_loss * self.train_config.diffusion_feature_extractor_weight 
+                additional_loss += (
+                    dfe_loss * self.train_config.diffusion_feature_extractor_weight
+                )
             else:
-                raise ValueError(f"Unknown diffusion feature extractor version {self.dfe.version}")
-                
-            
+                raise ValueError(
+                    f"Unknown diffusion feature extractor version {self.dfe.version}"
+                )
+
         if target is None:
             target = noise
 
         pred = noise_pred
 
         if self.train_config.train_turbo:
-            pred, target = self.process_output_for_turbo(pred, noisy_latents, timesteps, noise, batch)
+            pred, target = self.process_output_for_turbo(
+                pred, noisy_latents, timesteps, noise, batch
+            )
 
         ignore_snr = False
 
-        if loss_target == 'source' or loss_target == 'unaugmented':
+        if loss_target == "source" or loss_target == "unaugmented":
             assert not self.train_config.train_turbo
             # ignore_snr = True
             if batch.sigmas is None:
@@ -474,41 +585,58 @@ class SDTrainer(BaseSDTrainProcess):
 
             # src https://github.com/huggingface/diffusers/blob/324d18fba23f6c9d7475b0ff7c777685f7128d40/examples/t2i_adapter/train_t2i_adapter_sdxl.py#L1190
             denoised_latents = noise_pred * (-batch.sigmas) + noisy_latents
-            weighing = batch.sigmas ** -2.0
-            if loss_target == 'source':
+            weighing = batch.sigmas**-2.0
+            if loss_target == "source":
                 # denoise the latent and compare to the latent in the batch
                 target = batch.latents
-            elif loss_target == 'unaugmented':
+            elif loss_target == "unaugmented":
                 # we have to encode images into latents for now
                 # we also denoise as the unaugmented tensor is not a noisy diffirental
                 with torch.no_grad():
-                    unaugmented_latents = self.sd.encode_images(batch.unaugmented_tensor).to(self.device_torch, dtype=dtype)
-                    unaugmented_latents = unaugmented_latents * self.train_config.latent_multiplier
+                    unaugmented_latents = self.sd.encode_images(
+                        batch.unaugmented_tensor
+                    ).to(self.device_torch, dtype=dtype)
+                    unaugmented_latents = (
+                        unaugmented_latents * self.train_config.latent_multiplier
+                    )
                     target = unaugmented_latents.detach()
 
                 # Get the target for loss depending on the prediction type
                 if self.sd.noise_scheduler.config.prediction_type == "epsilon":
                     target = target  # we are computing loss against denoise latents
                 elif self.sd.noise_scheduler.config.prediction_type == "v_prediction":
-                    target = self.sd.noise_scheduler.get_velocity(target, noise, timesteps)
+                    target = self.sd.noise_scheduler.get_velocity(
+                        target, noise, timesteps
+                    )
                 else:
-                    raise ValueError(f"Unknown prediction type {self.sd.noise_scheduler.config.prediction_type}")
+                    raise ValueError(
+                        f"Unknown prediction type {self.sd.noise_scheduler.config.prediction_type}"
+                    )
 
             # mse loss without reduction
-            loss_per_element = (weighing.float() * (denoised_latents.float() - target.float()) ** 2)
+            loss_per_element = (
+                weighing.float() * (denoised_latents.float() - target.float()) ** 2
+            )
             loss = loss_per_element
         else:
 
             if self.train_config.loss_type == "mae":
-                loss = torch.nn.functional.l1_loss(pred.float(), target.float(), reduction="none")
+                loss = torch.nn.functional.l1_loss(
+                    pred.float(), target.float(), reduction="none"
+                )
             elif self.train_config.loss_type == "wavelet":
                 loss = wavelet_loss(pred, batch.latents, noise)
             else:
-                loss = torch.nn.functional.mse_loss(pred.float(), target.float(), reduction="none")
-                
+                loss = torch.nn.functional.mse_loss(
+                    pred.float(), target.float(), reduction="none"
+                )
+
             do_weighted_timesteps = False
             if self.sd.is_flow_matching:
-                if self.train_config.linear_timesteps or self.train_config.linear_timesteps2:
+                if (
+                    self.train_config.linear_timesteps
+                    or self.train_config.linear_timesteps2
+                ):
                     do_weighted_timesteps = True
                 if self.train_config.timestep_type == "weighted":
                     # use the noise scheduler to get the weights for the timesteps
@@ -520,7 +648,7 @@ class SDTrainer(BaseSDTrainProcess):
                 timestep_weight = self.sd.noise_scheduler.get_weights_for_timesteps(
                     timesteps,
                     v2=self.train_config.linear_timesteps2,
-                    timestep_type=self.train_config.timestep_type
+                    timestep_type=self.train_config.timestep_type,
                 ).to(loss.device, dtype=loss.dtype)
                 if len(loss.shape) == 4:
                     timestep_weight = timestep_weight.view(-1, 1, 1, 1).detach()
@@ -529,12 +657,19 @@ class SDTrainer(BaseSDTrainProcess):
                 loss = loss * timestep_weight
 
         if self.train_config.do_prior_divergence and prior_pred is not None:
-            loss = loss + (torch.nn.functional.mse_loss(pred.float(), prior_pred.float(), reduction="none") * -1.0)
+            loss = loss + (
+                torch.nn.functional.mse_loss(
+                    pred.float(), prior_pred.float(), reduction="none"
+                )
+                * -1.0
+            )
 
         if self.train_config.train_turbo:
             mask_multiplier = mask_multiplier[:, 3:, :, :]
             # resize to the size of the loss
-            mask_multiplier = torch.nn.functional.interpolate(mask_multiplier, size=(pred.shape[2], pred.shape[3]), mode='nearest')
+            mask_multiplier = torch.nn.functional.interpolate(
+                mask_multiplier, size=(pred.shape[2], pred.shape[3]), mode="nearest"
+            )
 
         # multiply by our mask
         try:
@@ -544,14 +679,26 @@ class SDTrainer(BaseSDTrainProcess):
             pass
 
         prior_loss = None
-        if self.train_config.inverted_mask_prior and prior_pred is not None and prior_mask_multiplier is not None:
+        if (
+            self.train_config.inverted_mask_prior
+            and prior_pred is not None
+            and prior_mask_multiplier is not None
+        ):
             assert not self.train_config.train_turbo
             if self.train_config.loss_type == "mae":
-                prior_loss = torch.nn.functional.l1_loss(pred.float(), prior_pred.float(), reduction="none")
+                prior_loss = torch.nn.functional.l1_loss(
+                    pred.float(), prior_pred.float(), reduction="none"
+                )
             else:
-                prior_loss = torch.nn.functional.mse_loss(pred.float(), prior_pred.float(), reduction="none")
+                prior_loss = torch.nn.functional.mse_loss(
+                    pred.float(), prior_pred.float(), reduction="none"
+                )
 
-            prior_loss = prior_loss * prior_mask_multiplier * self.train_config.inverted_mask_prior_multiplier
+            prior_loss = (
+                prior_loss
+                * prior_mask_multiplier
+                * self.train_config.inverted_mask_prior_multiplier
+            )
             if torch.isnan(prior_loss).any():
                 print_acc("Prior loss is nan")
                 prior_loss = None
@@ -575,18 +722,40 @@ class SDTrainer(BaseSDTrainProcess):
             if self.train_config.learnable_snr_gos:
                 # add snr_gamma
                 loss = apply_learnable_snr_gos(loss, timesteps, self.snr_gos)
-            elif self.train_config.snr_gamma is not None and self.train_config.snr_gamma > 0.000001 and not ignore_snr:
+            elif (
+                self.train_config.snr_gamma is not None
+                and self.train_config.snr_gamma > 0.000001
+                and not ignore_snr
+            ):
                 # add snr_gamma
-                loss = apply_snr_weight(loss, timesteps, self.sd.noise_scheduler, self.train_config.snr_gamma,
-                                        fixed=True)
-            elif self.train_config.min_snr_gamma is not None and self.train_config.min_snr_gamma > 0.000001 and not ignore_snr:
+                loss = apply_snr_weight(
+                    loss,
+                    timesteps,
+                    self.sd.noise_scheduler,
+                    self.train_config.snr_gamma,
+                    fixed=True,
+                )
+            elif (
+                self.train_config.min_snr_gamma is not None
+                and self.train_config.min_snr_gamma > 0.000001
+                and not ignore_snr
+            ):
                 # add min_snr_gamma
-                loss = apply_snr_weight(loss, timesteps, self.sd.noise_scheduler, self.train_config.min_snr_gamma)
+                loss = apply_snr_weight(
+                    loss,
+                    timesteps,
+                    self.sd.noise_scheduler,
+                    self.train_config.min_snr_gamma,
+                )
 
         loss = loss.mean()
 
         # check for additional losses
-        if self.adapter is not None and hasattr(self.adapter, "additional_loss") and self.adapter.additional_loss is not None:
+        if (
+            self.adapter is not None
+            and hasattr(self.adapter, "additional_loss")
+            and self.adapter.additional_loss is not None
+        ):
 
             loss = loss + self.adapter.additional_loss.mean()
             self.adapter.additional_loss = None
@@ -594,27 +763,28 @@ class SDTrainer(BaseSDTrainProcess):
         if self.train_config.target_norm_std:
             # seperate out the batch and channels
             pred_std = noise_pred.std([2, 3], keepdim=True)
-            norm_std_loss = torch.abs(self.train_config.target_norm_std_value - pred_std).mean()
+            norm_std_loss = torch.abs(
+                self.train_config.target_norm_std_value - pred_std
+            ).mean()
             loss = loss + norm_std_loss
-
 
         return loss + additional_loss
 
-    def preprocess_batch(self, batch: 'DataLoaderBatchDTO'):
+    def preprocess_batch(self, batch: "DataLoaderBatchDTO"):
         return batch
 
     def get_guided_loss(
-            self,
-            noisy_latents: torch.Tensor,
-            conditional_embeds: PromptEmbeds,
-            match_adapter_assist: bool,
-            network_weight_list: list,
-            timesteps: torch.Tensor,
-            pred_kwargs: dict,
-            batch: 'DataLoaderBatchDTO',
-            noise: torch.Tensor,
-            unconditional_embeds: Optional[PromptEmbeds] = None,
-            **kwargs
+        self,
+        noisy_latents: torch.Tensor,
+        conditional_embeds: PromptEmbeds,
+        match_adapter_assist: bool,
+        network_weight_list: list,
+        timesteps: torch.Tensor,
+        pred_kwargs: dict,
+        batch: "DataLoaderBatchDTO",
+        noise: torch.Tensor,
+        unconditional_embeds: Optional[PromptEmbeds] = None,
+        **kwargs,
     ):
         loss = get_guidance_loss(
             noisy_latents=noisy_latents,
@@ -628,12 +798,11 @@ class SDTrainer(BaseSDTrainProcess):
             sd=self.sd,
             unconditional_embeds=unconditional_embeds,
             train_config=self.train_config,
-            **kwargs
+            **kwargs,
         )
 
         return loss
-    
-    
+
     # ------------------------------------------------------------------
     #  Mean-Flow loss (Geng et al., “Mean Flows for One-step Generative
     #  Modelling”, 2025 – see Alg. 1 + Eq. (6) of the paper)
@@ -641,25 +810,29 @@ class SDTrainer(BaseSDTrainProcess):
     # adapted from the work of lodestonerock
     # ------------------------------------------------------------------
     def get_mean_flow_loss_wip(
-            self,
-            noisy_latents: torch.Tensor,
-            conditional_embeds: PromptEmbeds,
-            match_adapter_assist: bool,
-            network_weight_list: list,
-            timesteps: torch.Tensor,
-            pred_kwargs: dict,
-            batch: 'DataLoaderBatchDTO',
-            noise: torch.Tensor,
-            unconditional_embeds: Optional[PromptEmbeds] = None,
-            **kwargs
+        self,
+        noisy_latents: torch.Tensor,
+        conditional_embeds: PromptEmbeds,
+        match_adapter_assist: bool,
+        network_weight_list: list,
+        timesteps: torch.Tensor,
+        pred_kwargs: dict,
+        batch: "DataLoaderBatchDTO",
+        noise: torch.Tensor,
+        unconditional_embeds: Optional[PromptEmbeds] = None,
+        **kwargs,
     ):
-        batch_latents = batch.latents.to(self.device_torch, dtype=get_torch_dtype(self.train_config.dtype))
-        
-        
+        batch_latents = batch.latents.to(
+            self.device_torch, dtype=get_torch_dtype(self.train_config.dtype)
+        )
+
         time_end = timesteps.float() / 1000
         # for timestep_r, we need values from timestep_end to 0.0 randomly
-        time_origin = torch.rand_like(time_end, device=self.device_torch, dtype=time_end.dtype) * time_end
-        
+        time_origin = (
+            torch.rand_like(time_end, device=self.device_torch, dtype=time_end.dtype)
+            * time_end
+        )
+
         # time_origin = torch.zeros_like(time_end, device=self.device_torch, dtype=time_end.dtype)
         # Compute noised data points
         # lerp_vector = noisy_latents
@@ -669,7 +842,9 @@ class SDTrainer(BaseSDTrainProcess):
         # finite difference method
         epsilon_fd = 1e-3
         jitter_std = 1e-4
-        epsilon_jittered = epsilon_fd + torch.randn(1, device=batch_latents.device) * jitter_std
+        epsilon_jittered = (
+            epsilon_fd + torch.randn(1, device=batch_latents.device) * jitter_std
+        )
         epsilon_jittered = torch.clamp(epsilon_jittered, min=1e-4)
 
         # f(x + epsilon * v) for the primal (we backprop through here)
@@ -680,13 +855,15 @@ class SDTrainer(BaseSDTrainProcess):
             conditional_embeds=conditional_embeds,
             unconditional_embeds=unconditional_embeds,
             batch=batch,
-            **pred_kwargs
+            **pred_kwargs,
         )
 
         with torch.no_grad():
             perturbed_time_end = torch.clamp(time_end + epsilon_jittered, 0.0, 1.0)
             # intermediate vector to compute tangent approximation f(x + epsilon * v) ! NO GRAD HERE!
-            perturbed_lerp_vector = noisy_latents + epsilon_jittered * instantaneous_vector
+            perturbed_lerp_vector = (
+                noisy_latents + epsilon_jittered * instantaneous_vector
+            )
             # f_x_plus_eps_v = self.forward(perturbed_lerp_vector, class_label)
             f_x_plus_eps_v = self.predict_noise(
                 noisy_latents=perturbed_lerp_vector,
@@ -694,23 +871,22 @@ class SDTrainer(BaseSDTrainProcess):
                 conditional_embeds=conditional_embeds,
                 unconditional_embeds=unconditional_embeds,
                 batch=batch,
-                **pred_kwargs
+                **pred_kwargs,
             )
 
         # JVP approximation: (f(x + epsilon * v) - f(x)) / epsilon
         mean_vec_grad_fd = (f_x_plus_eps_v - mean_vec_val_pred) / epsilon_jittered
         mean_vec_grad = mean_vec_grad_fd
-        
 
         # calculate the regression target the mean vector
         time_difference_broadcast = (time_end - time_origin)[:, None, None, None]
-        mean_vec_target = instantaneous_vector - time_difference_broadcast * mean_vec_grad
+        mean_vec_target = (
+            instantaneous_vector - time_difference_broadcast * mean_vec_grad
+        )
 
         # 5) MSE loss
         loss = torch.nn.functional.mse_loss(
-            mean_vec_val_pred.float(),
-            mean_vec_target.float(),
-            reduction='none'
+            mean_vec_val_pred.float(), mean_vec_target.float(), reduction="none"
         )
         with torch.no_grad():
             pure_loss = loss.mean().detach()
@@ -722,14 +898,13 @@ class SDTrainer(BaseSDTrainProcess):
             loss_mean = loss.mean([1, 2, 3], keepdim=True)
         loss = loss / loss_mean
         loss = loss.mean()
-        
+
         # backward the pure loss for logging
         self.accelerator.backward(loss)
-        
+
         # return the real loss for logging
         return pure_loss
 
-    
     # ------------------------------------------------------------------
     #  Mean-Flow loss (Geng et al., “Mean Flows for One-step Generative
     #  Modelling”, 2025 – see Alg. 1 + Eq. (6) of the paper)
@@ -737,26 +912,26 @@ class SDTrainer(BaseSDTrainProcess):
     # adapted from the work of lodestonerock
     # ------------------------------------------------------------------
     def get_mean_flow_loss(
-            self,
-            noisy_latents: torch.Tensor,
-            conditional_embeds: PromptEmbeds,
-            match_adapter_assist: bool,
-            network_weight_list: list,
-            timesteps: torch.Tensor,
-            pred_kwargs: dict,
-            batch: 'DataLoaderBatchDTO',
-            noise: torch.Tensor,
-            unconditional_embeds: Optional[PromptEmbeds] = None,
-            **kwargs
+        self,
+        noisy_latents: torch.Tensor,
+        conditional_embeds: PromptEmbeds,
+        match_adapter_assist: bool,
+        network_weight_list: list,
+        timesteps: torch.Tensor,
+        pred_kwargs: dict,
+        batch: "DataLoaderBatchDTO",
+        noise: torch.Tensor,
+        unconditional_embeds: Optional[PromptEmbeds] = None,
+        **kwargs,
     ):
-         # ------------------------------------------------------------------
+        # ------------------------------------------------------------------
         #  “Slow” Mean-Flow loss – finite-difference version
         #  (avoids JVP / double-backprop issues with Flash-Attention)
         # ------------------------------------------------------------------
-        dtype        = get_torch_dtype(self.train_config.dtype)
-        total_steps  = float(self.sd.noise_scheduler.config.num_train_timesteps)  # 1000
-        base_eps = 1e-3 # this is one step when multiplied by 1000
-        
+        dtype = get_torch_dtype(self.train_config.dtype)
+        total_steps = float(self.sd.noise_scheduler.config.num_train_timesteps)  # 1000
+        base_eps = 1e-3  # this is one step when multiplied by 1000
+
         with torch.no_grad():
             num_train_timesteps = self.sd.noise_scheduler.config.num_train_timesteps
             batch_size = batch.latents.shape[0]
@@ -780,36 +955,33 @@ class SDTrainer(BaseSDTrainProcess):
             timesteps_t = torch.stack(timestep_t_list, dim=0).float()
             timesteps_r = torch.stack(timestep_r_list, dim=0).float()
 
-            # fractions in [0,1] 
+            # fractions in [0,1]
             t_frac = timesteps_t / total_steps
             r_frac = timesteps_r / total_steps
 
             # 2) construct data points
-            latents_clean  = batch.latents.to(dtype)
-            noise_sample   = noise.to(dtype)
+            latents_clean = batch.latents.to(dtype)
+            noise_sample = noise.to(dtype)
 
-            lerp_vector = noise_sample * t_frac[:, None, None, None] \
-                        + latents_clean * (1.0 - t_frac[:, None, None, None])
+            lerp_vector = noise_sample * t_frac[:, None, None, None] + latents_clean * (
+                1.0 - t_frac[:, None, None, None]
+            )
 
-            if hasattr(self.sd, 'get_loss_target'):
+            if hasattr(self.sd, "get_loss_target"):
                 instantaneous_vector = self.sd.get_loss_target(
                     noise=noise_sample,
                     batch=batch,
                     timesteps=timesteps,
                 ).detach()
             else:
-                instantaneous_vector = noise_sample - latents_clean          # v_t   (B,C,H,W)
+                instantaneous_vector = noise_sample - latents_clean  # v_t   (B,C,H,W)
 
             # 3) finite-difference JVP approximation (bump z **and** t)
             # eps_base, eps_jitter = 1e-3, 1e-4
             # eps = (eps_base + torch.randn(1, device=lerp_vector.device) * eps_jitter).clamp_(min=1e-4)
             jitter = 1e-4
             eps = value_map(
-                torch.rand_like(t_frac),
-                0.0,
-                1.0,
-                base_eps,
-                base_eps + jitter
+                torch.rand_like(t_frac), 0.0, 1.0, base_eps, base_eps + jitter
             )
 
         # eps = 1e-3
@@ -820,15 +992,16 @@ class SDTrainer(BaseSDTrainProcess):
             conditional_embeds=conditional_embeds,
             unconditional_embeds=unconditional_embeds,
             batch=batch,
-            **pred_kwargs
+            **pred_kwargs,
         )
 
         # secondary prediction: bump both latent and timestep by ε
         with torch.no_grad():
             # lerp_perturbed   = lerp_vector + eps * instantaneous_vector
-            t_frac_plus_eps  = t_frac + eps                      # bump time fraction
-            lerp_perturbed = noise_sample * t_frac_plus_eps[:, None, None, None] \
-                    + latents_clean * (1.0 - t_frac_plus_eps[:, None, None, None])
+            t_frac_plus_eps = t_frac + eps  # bump time fraction
+            lerp_perturbed = noise_sample * t_frac_plus_eps[
+                :, None, None, None
+            ] + latents_clean * (1.0 - t_frac_plus_eps[:, None, None, None])
 
             f_x_plus_eps_v = self.predict_noise(
                 noisy_latents=lerp_perturbed,
@@ -836,7 +1009,7 @@ class SDTrainer(BaseSDTrainProcess):
                 conditional_embeds=conditional_embeds,
                 unconditional_embeds=unconditional_embeds,
                 batch=batch,
-                **pred_kwargs
+                **pred_kwargs,
             )
 
             # finite-difference JVP:  (f(x+εv) – f(x)) / ε
@@ -859,9 +1032,7 @@ class SDTrainer(BaseSDTrainProcess):
         # return loss
         # 5) MSE loss
         loss = torch.nn.functional.mse_loss(
-            mean_vec_pred.float(),
-            mean_vec_target.float(),
-            reduction='none'
+            mean_vec_pred.float(), mean_vec_target.float(), reduction="none"
         )
         with torch.no_grad():
             pure_loss = loss.mean().detach()
@@ -873,28 +1044,26 @@ class SDTrainer(BaseSDTrainProcess):
         #     loss_mean = loss.mean([1, 2, 3], keepdim=True)
         # loss = loss / loss_mean
         loss = loss.mean()
-        
+
         # backward the pure loss for logging
         self.accelerator.backward(loss)
-        
+
         # return the real loss for logging
         return pure_loss
 
-
-
     def get_prior_prediction(
-            self,
-            noisy_latents: torch.Tensor,
-            conditional_embeds: PromptEmbeds,
-            match_adapter_assist: bool,
-            network_weight_list: list,
-            timesteps: torch.Tensor,
-            pred_kwargs: dict,
-            batch: 'DataLoaderBatchDTO',
-            noise: torch.Tensor,
-            unconditional_embeds: Optional[PromptEmbeds] = None,
-            conditioned_prompts=None,
-            **kwargs
+        self,
+        noisy_latents: torch.Tensor,
+        conditional_embeds: PromptEmbeds,
+        match_adapter_assist: bool,
+        network_weight_list: list,
+        timesteps: torch.Tensor,
+        pred_kwargs: dict,
+        batch: "DataLoaderBatchDTO",
+        noise: torch.Tensor,
+        unconditional_embeds: Optional[PromptEmbeds] = None,
+        conditioned_prompts=None,
+        **kwargs,
     ):
         # todo for embeddings, we need to run without trigger words
         was_unet_training = self.sd.unet.training
@@ -904,27 +1073,36 @@ class SDTrainer(BaseSDTrainProcess):
             self.network.is_active = False
         can_disable_adapter = False
         was_adapter_active = False
-        if self.adapter is not None and (isinstance(self.adapter, IPAdapter) or
-                                         isinstance(self.adapter, ReferenceAdapter) or
-                                         (isinstance(self.adapter, CustomAdapter))
+        if self.adapter is not None and (
+            isinstance(self.adapter, IPAdapter)
+            or isinstance(self.adapter, ReferenceAdapter)
+            or (isinstance(self.adapter, CustomAdapter))
         ):
             can_disable_adapter = True
             was_adapter_active = self.adapter.is_active
             self.adapter.is_active = False
 
-        if self.train_config.unload_text_encoder and self.adapter is not None and not isinstance(self.adapter, CustomAdapter):
-            raise ValueError("Prior predictions currently do not support unloading text encoder with adapter")
+        if (
+            self.train_config.unload_text_encoder
+            and self.adapter is not None
+            and not isinstance(self.adapter, CustomAdapter)
+        ):
+            raise ValueError(
+                "Prior predictions currently do not support unloading text encoder with adapter"
+            )
         # do a prediction here so we can match its output with network multiplier set to 0.0
         with torch.no_grad():
             dtype = get_torch_dtype(self.train_config.dtype)
 
             embeds_to_use = conditional_embeds.clone().detach()
             # handle clip vision adapter by removing triggers from prompt and replacing with the class name
-            if (self.adapter is not None and isinstance(self.adapter, ClipVisionAdapter)) or self.embedding is not None:
+            if (
+                self.adapter is not None and isinstance(self.adapter, ClipVisionAdapter)
+            ) or self.embedding is not None:
                 prompt_list = batch.get_caption_list()
-                class_name = ''
+                class_name = ""
 
-                triggers = ['[trigger]', '[name]']
+                triggers = ["[trigger]", "[name]"]
                 remove_tokens = []
 
                 if self.embed_config is not None:
@@ -943,53 +1121,74 @@ class SDTrainer(BaseSDTrainProcess):
 
                 for idx, prompt in enumerate(prompt_list):
                     for remove_token in remove_tokens:
-                        prompt = prompt.replace(remove_token, '')
+                        prompt = prompt.replace(remove_token, "")
                     for trigger in triggers:
                         prompt = prompt.replace(trigger, class_name)
                     prompt_list[idx] = prompt
 
-                embeds_to_use = self.sd.encode_prompt(
-                    prompt_list,
-                    long_prompts=self.do_long_prompts).to(
-                    self.device_torch,
-                    dtype=dtype).detach()
+                embeds_to_use = (
+                    self.sd.encode_prompt(
+                        prompt_list, long_prompts=self.do_long_prompts
+                    )
+                    .to(self.device_torch, dtype=dtype)
+                    .detach()
+                )
 
             # dont use network on this
             # self.network.multiplier = 0.0
             self.sd.unet.eval()
 
-            if self.adapter is not None and isinstance(self.adapter, IPAdapter) and not self.sd.is_flux and not self.sd.is_lumina2:
+            if (
+                self.adapter is not None
+                and isinstance(self.adapter, IPAdapter)
+                and not self.sd.is_flux
+                and not self.sd.is_lumina2
+            ):
                 # we need to remove the image embeds from the prompt except for flux
                 embeds_to_use: PromptEmbeds = embeds_to_use.clone().detach()
-                end_pos = embeds_to_use.text_embeds.shape[1] - self.adapter_config.num_tokens
+                end_pos = (
+                    embeds_to_use.text_embeds.shape[1] - self.adapter_config.num_tokens
+                )
                 embeds_to_use.text_embeds = embeds_to_use.text_embeds[:, :end_pos, :]
                 if unconditional_embeds is not None:
                     unconditional_embeds = unconditional_embeds.clone().detach()
-                    unconditional_embeds.text_embeds = unconditional_embeds.text_embeds[:, :end_pos]
+                    unconditional_embeds.text_embeds = unconditional_embeds.text_embeds[
+                        :, :end_pos
+                    ]
 
             if unconditional_embeds is not None:
-                unconditional_embeds = unconditional_embeds.to(self.device_torch, dtype=dtype).detach()
+                unconditional_embeds = unconditional_embeds.to(
+                    self.device_torch, dtype=dtype
+                ).detach()
 
             prior_pred = self.sd.predict_noise(
                 latents=noisy_latents.to(self.device_torch, dtype=dtype).detach(),
-                conditional_embeddings=embeds_to_use.to(self.device_torch, dtype=dtype).detach(),
+                conditional_embeddings=embeds_to_use.to(
+                    self.device_torch, dtype=dtype
+                ).detach(),
                 unconditional_embeddings=unconditional_embeds,
                 timestep=timesteps,
                 guidance_scale=self.train_config.cfg_scale,
                 rescale_cfg=self.train_config.cfg_rescale,
                 batch=batch,
-                **pred_kwargs  # adapter residuals in here
+                **pred_kwargs,  # adapter residuals in here
             )
             if was_unet_training:
                 self.sd.unet.train()
             prior_pred = prior_pred.detach()
             # remove the residuals as we wont use them on prediction when matching control
-            if match_adapter_assist and 'down_intrablock_additional_residuals' in pred_kwargs:
-                del pred_kwargs['down_intrablock_additional_residuals']
-            if match_adapter_assist and 'down_block_additional_residuals' in pred_kwargs:
-                del pred_kwargs['down_block_additional_residuals']
-            if match_adapter_assist and 'mid_block_additional_residual' in pred_kwargs:
-                del pred_kwargs['mid_block_additional_residual']
+            if (
+                match_adapter_assist
+                and "down_intrablock_additional_residuals" in pred_kwargs
+            ):
+                del pred_kwargs["down_intrablock_additional_residuals"]
+            if (
+                match_adapter_assist
+                and "down_block_additional_residuals" in pred_kwargs
+            ):
+                del pred_kwargs["down_block_additional_residuals"]
+            if match_adapter_assist and "mid_block_additional_residual" in pred_kwargs:
+                del pred_kwargs["mid_block_additional_residual"]
 
             if can_disable_adapter:
                 self.adapter.is_active = was_adapter_active
@@ -1014,14 +1213,16 @@ class SDTrainer(BaseSDTrainProcess):
         timesteps: Union[int, torch.Tensor] = 1,
         conditional_embeds: Union[PromptEmbeds, None] = None,
         unconditional_embeds: Union[PromptEmbeds, None] = None,
-        batch: Optional['DataLoaderBatchDTO'] = None,
+        batch: Optional["DataLoaderBatchDTO"] = None,
         is_primary_pred: bool = False,
         **kwargs,
     ):
         dtype = get_torch_dtype(self.train_config.dtype)
         return self.sd.predict_noise(
             latents=noisy_latents.to(self.device_torch, dtype=dtype),
-            conditional_embeddings=conditional_embeds.to(self.device_torch, dtype=dtype),
+            conditional_embeddings=conditional_embeds.to(
+                self.device_torch, dtype=dtype
+            ),
             unconditional_embeddings=unconditional_embeds,
             timestep=timesteps,
             guidance_scale=self.train_config.cfg_scale,
@@ -1030,13 +1231,10 @@ class SDTrainer(BaseSDTrainProcess):
             rescale_cfg=self.train_config.cfg_rescale,
             bypass_guidance_embedding=self.train_config.bypass_guidance_embedding,
             batch=batch,
-            **kwargs
+            **kwargs,
         )
-    
-    def cfm_augment_tensors(
-        self,
-        images: torch.Tensor
-    ) -> torch.Tensor:
+
+    def cfm_augment_tensors(self, images: torch.Tensor) -> torch.Tensor:
         if self.cfm_cache is None:
             # flip the current one. Only need this for first time
             self.cfm_cache = torch.flip(images, [3]).clone()
@@ -1044,13 +1242,15 @@ class SDTrainer(BaseSDTrainProcess):
         for i in range(images.shape[0]):
             # get a random one
             idx = random.randint(0, self.cfm_cache.shape[0] - 1)
-            augmented_tensor_list.append(self.cfm_cache[idx:idx + 1])
+            augmented_tensor_list.append(self.cfm_cache[idx : idx + 1])
         augmented = torch.cat(augmented_tensor_list, dim=0)
         # resize to match the input
-        augmented = torch.nn.functional.interpolate(augmented, size=(images.shape[2], images.shape[3]), mode='bilinear')
+        augmented = torch.nn.functional.interpolate(
+            augmented, size=(images.shape[2], images.shape[3]), mode="bilinear"
+        )
         self.cfm_cache = images.clone()
         return augmented
-    
+
     def get_cfm_loss(
         self,
         noisy_latents: torch.Tensor,
@@ -1058,27 +1258,33 @@ class SDTrainer(BaseSDTrainProcess):
         noise_pred: torch.Tensor,
         conditional_embeds: PromptEmbeds,
         timesteps: torch.Tensor,
-        batch: 'DataLoaderBatchDTO',
+        batch: "DataLoaderBatchDTO",
         alpha: float = 0.1,
     ):
         dtype = get_torch_dtype(self.train_config.dtype)
-        if hasattr(self.sd, 'get_loss_target'):
+        if hasattr(self.sd, "get_loss_target"):
             target = self.sd.get_loss_target(
-                noise=noise, 
-                batch=batch, 
+                noise=noise,
+                batch=batch,
                 timesteps=timesteps,
             ).detach()
-            
+
         elif self.sd.is_flow_matching:
             # forward ODE
             target = (noise - batch.latents).detach()
         else:
             raise ValueError("CFM loss only works with flow matching")
-        fm_loss = torch.nn.functional.mse_loss(noise_pred.float(), target.float(), reduction="none")
+        fm_loss = torch.nn.functional.mse_loss(
+            noise_pred.float(), target.float(), reduction="none"
+        )
         with torch.no_grad():
             # we need to compute the contrast
-            cfm_batch_tensors = self.cfm_augment_tensors(batch.tensor).to(self.device_torch, dtype=dtype)
-            cfm_latents = self.sd.encode_images(cfm_batch_tensors).to(self.device_torch, dtype=dtype)
+            cfm_batch_tensors = self.cfm_augment_tensors(batch.tensor).to(
+                self.device_torch, dtype=dtype
+            )
+            cfm_latents = self.sd.encode_images(cfm_batch_tensors).to(
+                self.device_torch, dtype=dtype
+            )
             cfm_noisy_latents = self.sd.add_noise(
                 original_samples=cfm_latents,
                 noise=noise,
@@ -1091,25 +1297,25 @@ class SDTrainer(BaseSDTrainProcess):
                 unconditional_embeds=None,
                 batch=batch,
             )
-            
+
         # v_neg = torch.nn.functional.normalize(cfm_pred.float(), dim=1)
         # v_pos = torch.nn.functional.normalize(noise_pred.float(), dim=1)  # shape: (B, C, H, W)
 
         # # Compute cosine similarity at each pixel
         # sim = (v_pos * v_neg).sum(dim=1)  # shape: (B, H, W)
-        
+
         cos = torch.nn.CosineSimilarity(dim=1, eps=1e-6)
         # Compute cosine similarity at each pixel
         sim = cos(cfm_pred.float(), noise_pred.float())  # shape: (B, H, W)
 
         # Average over spatial dimensions, then batch
         contrastive_loss = -sim.mean()
-        
+
         loss = fm_loss.mean() + alpha * contrastive_loss
         return loss
 
     def train_single_accumulation(self, batch: DataLoaderBatchDTO):
-        self.timer.start('preprocess_batch')
+        self.timer.start("preprocess_batch")
         if isinstance(self.adapter, CustomAdapter):
             batch = self.adapter.edit_batch_raw(batch)
         batch = self.preprocess_batch(batch)
@@ -1127,19 +1333,23 @@ class SDTrainer(BaseSDTrainProcess):
             if self.sd.text_encoder.dtype != self.sd.te_torch_dtype:
                 self.sd.text_encoder.to(self.sd.te_torch_dtype)
 
-        noisy_latents, noise, timesteps, conditioned_prompts, imgs = self.process_general_training_batch(batch)
+        noisy_latents, noise, timesteps, conditioned_prompts, imgs = (
+            self.process_general_training_batch(batch)
+        )
         if self.train_config.do_cfg or self.train_config.do_random_cfg:
             # pick random negative prompts
             if self.negative_prompt_pool is not None:
                 negative_prompts = []
                 for i in range(noisy_latents.shape[0]):
                     num_neg = random.randint(1, self.train_config.max_negative_prompts)
-                    this_neg_prompts = [random.choice(self.negative_prompt_pool) for _ in range(num_neg)]
-                    this_neg_prompt = ', '.join(this_neg_prompts)
+                    this_neg_prompts = [
+                        random.choice(self.negative_prompt_pool) for _ in range(num_neg)
+                    ]
+                    this_neg_prompt = ", ".join(this_neg_prompts)
                     negative_prompts.append(this_neg_prompt)
                 self.batch_negative_prompt = negative_prompts
             else:
-                self.batch_negative_prompt = ['' for _ in range(batch.latents.shape[0])]
+                self.batch_negative_prompt = ["" for _ in range(batch.latents.shape[0])]
 
         if self.adapter and isinstance(self.adapter, CustomAdapter):
             # condition the prompt
@@ -1157,12 +1367,20 @@ class SDTrainer(BaseSDTrainProcess):
         if any([batch.file_items[idx].is_reg for idx in range(len(batch.file_items))]):
             has_clip_image = True
             if self._clip_image_embeds_unconditional is not None:
-                has_clip_image_embeds = True  # we are caching embeds, handle that differently
+                has_clip_image_embeds = (
+                    True  # we are caching embeds, handle that differently
+                )
                 has_clip_image = False
 
-        if self.adapter is not None and isinstance(self.adapter, IPAdapter) and not has_clip_image and has_adapter_img:
+        if (
+            self.adapter is not None
+            and isinstance(self.adapter, IPAdapter)
+            and not has_clip_image
+            and has_adapter_img
+        ):
             raise ValueError(
-                "IPAdapter control image is now 'clip_image_path' instead of 'control_path'. Please update your dataset config ")
+                "IPAdapter control image is now 'clip_image_path' instead of 'control_path'. Please update your dataset config "
+            )
 
         match_adapter_assist = False
 
@@ -1171,27 +1389,34 @@ class SDTrainer(BaseSDTrainProcess):
             if self.train_config.match_adapter_chance == 1.0:
                 match_adapter_assist = True
             elif self.train_config.match_adapter_chance > 0.0:
-                match_adapter_assist = torch.rand(
-                    (1,), device=self.device_torch, dtype=dtype
-                ) < self.train_config.match_adapter_chance
+                match_adapter_assist = (
+                    torch.rand((1,), device=self.device_torch, dtype=dtype)
+                    < self.train_config.match_adapter_chance
+                )
 
-        self.timer.stop('preprocess_batch')
+        self.timer.stop("preprocess_batch")
 
         is_reg = False
         with torch.no_grad():
-            loss_multiplier = torch.ones((noisy_latents.shape[0], 1, 1, 1), device=self.device_torch, dtype=dtype)
+            loss_multiplier = torch.ones(
+                (noisy_latents.shape[0], 1, 1, 1), device=self.device_torch, dtype=dtype
+            )
             for idx, file_item in enumerate(batch.file_items):
                 if file_item.is_reg:
-                    loss_multiplier[idx] = loss_multiplier[idx] * self.train_config.reg_weight
+                    loss_multiplier[idx] = (
+                        loss_multiplier[idx] * self.train_config.reg_weight
+                    )
                     is_reg = True
 
             adapter_images = None
             sigmas = None
             if has_adapter_img and (self.adapter or self.assistant_adapter):
-                with self.timer('get_adapter_images'):
+                with self.timer("get_adapter_images"):
                     # todo move this to data loader
                     if batch.control_tensor is not None:
-                        adapter_images = batch.control_tensor.to(self.device_torch, dtype=dtype).detach()
+                        adapter_images = batch.control_tensor.to(
+                            self.device_torch, dtype=dtype
+                        ).detach()
                         # match in channels
                         if self.assistant_adapter is not None:
                             in_channels = self.assistant_adapter.config.in_channels
@@ -1199,27 +1424,40 @@ class SDTrainer(BaseSDTrainProcess):
                                 # we need to match the channels
                                 adapter_images = adapter_images[:, :in_channels, :, :]
                     else:
-                        raise NotImplementedError("Adapter images now must be loaded with dataloader")
+                        raise NotImplementedError(
+                            "Adapter images now must be loaded with dataloader"
+                        )
 
             clip_images = None
             if has_clip_image:
-                with self.timer('get_clip_images'):
+                with self.timer("get_clip_images"):
                     # todo move this to data loader
                     if batch.clip_image_tensor is not None:
-                        clip_images = batch.clip_image_tensor.to(self.device_torch, dtype=dtype).detach()
+                        clip_images = batch.clip_image_tensor.to(
+                            self.device_torch, dtype=dtype
+                        ).detach()
 
-            mask_multiplier = torch.ones((noisy_latents.shape[0], 1, 1, 1), device=self.device_torch, dtype=dtype)
+            mask_multiplier = torch.ones(
+                (noisy_latents.shape[0], 1, 1, 1), device=self.device_torch, dtype=dtype
+            )
             if batch.mask_tensor is not None:
-                with self.timer('get_mask_multiplier'):
+                with self.timer("get_mask_multiplier"):
                     # upsampling no supported for bfloat16
-                    mask_multiplier = batch.mask_tensor.to(self.device_torch, dtype=torch.float16).detach()
+                    mask_multiplier = batch.mask_tensor.to(
+                        self.device_torch, dtype=torch.float16
+                    ).detach()
                     # scale down to the size of the latents, mask multiplier shape(bs, 1, width, height), noisy_latents shape(bs, channels, width, height)
                     mask_multiplier = torch.nn.functional.interpolate(
-                        mask_multiplier, size=(noisy_latents.shape[2], noisy_latents.shape[3])
+                        mask_multiplier,
+                        size=(noisy_latents.shape[2], noisy_latents.shape[3]),
                     )
                     # expand to match latents
-                    mask_multiplier = mask_multiplier.expand(-1, noisy_latents.shape[1], -1, -1)
-                    mask_multiplier = mask_multiplier.to(self.device_torch, dtype=dtype).detach()
+                    mask_multiplier = mask_multiplier.expand(
+                        -1, noisy_latents.shape[1], -1, -1
+                    )
+                    mask_multiplier = mask_multiplier.to(
+                        self.device_torch, dtype=dtype
+                    ).detach()
                     # make avg 1.0
                     mask_multiplier = mask_multiplier / mask_multiplier.mean()
 
@@ -1247,12 +1485,12 @@ class SDTrainer(BaseSDTrainProcess):
                 0.0,
                 1.0,
                 adapter_strength_min,
-                adapter_strength_max
+                adapter_strength_max,
             )
             return adapter_conditioning_scale
 
         # flush()
-        with self.timer('grad_setup'):
+        with self.timer("grad_setup"):
 
             # text encoding
             grad_on_text_encoder = False
@@ -1265,7 +1503,7 @@ class SDTrainer(BaseSDTrainProcess):
             if self.adapter and isinstance(self.adapter, ClipVisionAdapter):
                 grad_on_text_encoder = True
 
-            if self.adapter_config and self.adapter_config.type == 'te_augmenter':
+            if self.adapter_config and self.adapter_config.type == "te_augmenter":
                 grad_on_text_encoder = True
 
             # have a blank network so we can wrap it in a context and set multipliers without checking every time
@@ -1288,7 +1526,9 @@ class SDTrainer(BaseSDTrainProcess):
             # make the batch splits
         if self.train_config.single_item_batching:
             if self.model_config.refiner_name_or_path is not None:
-                raise ValueError("Single item batching is not supported when training the refiner")
+                raise ValueError(
+                    "Single item batching is not supported when training the refiner"
+                )
             batch_size = noisy_latents.shape[0]
             # chunk/split everything
             noisy_latents_list = torch.chunk(noisy_latents, batch_size, dim=0)
@@ -1327,16 +1567,26 @@ class SDTrainer(BaseSDTrainProcess):
             else:
                 prompt_2_list = [prompts_2]
 
-        for noisy_latents, noise, timesteps, conditioned_prompts, imgs, adapter_images, clip_images, mask_multiplier, prompt_2 in zip(
-                noisy_latents_list,
-                noise_list,
-                timesteps_list,
-                conditioned_prompts_list,
-                imgs_list,
-                adapter_images_list,
-                clip_images_list,
-                mask_multiplier_list,
-                prompt_2_list
+        for (
+            noisy_latents,
+            noise,
+            timesteps,
+            conditioned_prompts,
+            imgs,
+            adapter_images,
+            clip_images,
+            mask_multiplier,
+            prompt_2,
+        ) in zip(
+            noisy_latents_list,
+            noise_list,
+            timesteps_list,
+            conditioned_prompts_list,
+            imgs_list,
+            adapter_images_list,
+            clip_images_list,
+            mask_multiplier_list,
+            prompt_2_list,
         ):
 
             # if self.train_config.negative_prompt is not None:
@@ -1346,60 +1596,79 @@ class SDTrainer(BaseSDTrainProcess):
             #     if prompt_2 is not None:
             #         prompt_2 = prompt_2 + [self.train_config.negative_prompt for x in range(len(prompt_2))]
 
-            with (network):
+            with network:
                 # encode clip adapter here so embeds are active for tokenizer
                 if self.adapter and isinstance(self.adapter, ClipVisionAdapter):
-                    with self.timer('encode_clip_vision_embeds'):
+                    with self.timer("encode_clip_vision_embeds"):
                         if has_clip_image:
-                            conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                                clip_images.detach().to(self.device_torch, dtype=dtype),
-                                is_training=True,
-                                has_been_preprocessed=True
+                            conditional_clip_embeds = (
+                                self.adapter.get_clip_image_embeds_from_tensors(
+                                    clip_images.detach().to(
+                                        self.device_torch, dtype=dtype
+                                    ),
+                                    is_training=True,
+                                    has_been_preprocessed=True,
+                                )
                             )
                         else:
                             # just do a blank one
-                            conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                                torch.zeros(
-                                    (noisy_latents.shape[0], 3, 512, 512),
-                                    device=self.device_torch, dtype=dtype
-                                ),
-                                is_training=True,
-                                has_been_preprocessed=True,
-                                drop=True
+                            conditional_clip_embeds = (
+                                self.adapter.get_clip_image_embeds_from_tensors(
+                                    torch.zeros(
+                                        (noisy_latents.shape[0], 3, 512, 512),
+                                        device=self.device_torch,
+                                        dtype=dtype,
+                                    ),
+                                    is_training=True,
+                                    has_been_preprocessed=True,
+                                    drop=True,
+                                )
                             )
                         # it will be injected into the tokenizer when called
                         self.adapter(conditional_clip_embeds)
 
                 # do the custom adapter after the prior prediction
-                if self.adapter and isinstance(self.adapter, CustomAdapter) and (has_clip_image or is_reg):
+                if (
+                    self.adapter
+                    and isinstance(self.adapter, CustomAdapter)
+                    and (has_clip_image or is_reg)
+                ):
                     quad_count = random.randint(1, 4)
                     self.adapter.train()
                     self.adapter.trigger_pre_te(
-                        tensors_preprocessed=clip_images if not is_reg else None,  # on regs we send none to get random noise
+                        tensors_preprocessed=(
+                            clip_images if not is_reg else None
+                        ),  # on regs we send none to get random noise
                         is_training=True,
                         has_been_preprocessed=True,
                         quad_count=quad_count,
                         batch_tensor=batch.tensor if not is_reg else None,
-                        batch_size=noisy_latents.shape[0]
+                        batch_size=noisy_latents.shape[0],
                     )
 
-                with self.timer('encode_prompt'):
+                with self.timer("encode_prompt"):
                     unconditional_embeds = None
                     if self.train_config.unload_text_encoder:
                         with torch.set_grad_enabled(False):
-                            embeds_to_use = self.cached_blank_embeds.clone().detach().to(
-                                self.device_torch, dtype=dtype
+                            embeds_to_use = (
+                                self.cached_blank_embeds.clone()
+                                .detach()
+                                .to(self.device_torch, dtype=dtype)
                             )
                             if self.cached_trigger_embeds is not None and not is_reg:
-                                embeds_to_use = self.cached_trigger_embeds.clone().detach().to(
-                                    self.device_torch, dtype=dtype
+                                embeds_to_use = (
+                                    self.cached_trigger_embeds.clone()
+                                    .detach()
+                                    .to(self.device_torch, dtype=dtype)
                                 )
                             conditional_embeds = concat_prompt_embeds(
                                 [embeds_to_use] * noisy_latents.shape[0]
                             )
                             if self.train_config.do_cfg:
-                                unconditional_embeds = self.cached_blank_embeds.clone().detach().to(
-                                    self.device_torch, dtype=dtype
+                                unconditional_embeds = (
+                                    self.cached_blank_embeds.clone()
+                                    .detach()
+                                    .to(self.device_torch, dtype=dtype)
                                 )
                                 unconditional_embeds = concat_prompt_embeds(
                                     [unconditional_embeds] * noisy_latents.shape[0]
@@ -1413,11 +1682,11 @@ class SDTrainer(BaseSDTrainProcess):
                             if isinstance(self.adapter, CustomAdapter):
                                 self.adapter.is_unconditional_run = False
                             conditional_embeds = self.sd.encode_prompt(
-                                conditioned_prompts, prompt_2,
+                                conditioned_prompts,
+                                prompt_2,
                                 dropout_prob=self.train_config.prompt_dropout_prob,
-                                long_prompts=self.do_long_prompts).to(
-                                self.device_torch,
-                                dtype=dtype)
+                                long_prompts=self.do_long_prompts,
+                            ).to(self.device_torch, dtype=dtype)
 
                             if self.train_config.do_cfg:
                                 if isinstance(self.adapter, CustomAdapter):
@@ -1427,9 +1696,8 @@ class SDTrainer(BaseSDTrainProcess):
                                     self.batch_negative_prompt,
                                     self.batch_negative_prompt,
                                     dropout_prob=self.train_config.prompt_dropout_prob,
-                                    long_prompts=self.do_long_prompts).to(
-                                    self.device_torch,
-                                    dtype=dtype)
+                                    long_prompts=self.do_long_prompts,
+                                ).to(self.device_torch, dtype=dtype)
                                 if isinstance(self.adapter, CustomAdapter):
                                     self.adapter.is_unconditional_run = False
                     else:
@@ -1443,47 +1711,59 @@ class SDTrainer(BaseSDTrainProcess):
                             if isinstance(self.adapter, CustomAdapter):
                                 self.adapter.is_unconditional_run = False
                             conditional_embeds = self.sd.encode_prompt(
-                                conditioned_prompts, prompt_2,
+                                conditioned_prompts,
+                                prompt_2,
                                 dropout_prob=self.train_config.prompt_dropout_prob,
-                                long_prompts=self.do_long_prompts).to(
-                                self.device_torch,
-                                dtype=dtype)
+                                long_prompts=self.do_long_prompts,
+                            ).to(self.device_torch, dtype=dtype)
                             if self.train_config.do_cfg:
                                 if isinstance(self.adapter, CustomAdapter):
                                     self.adapter.is_unconditional_run = True
                                 unconditional_embeds = self.sd.encode_prompt(
                                     self.batch_negative_prompt,
                                     dropout_prob=self.train_config.prompt_dropout_prob,
-                                    long_prompts=self.do_long_prompts).to(
-                                    self.device_torch,
-                                    dtype=dtype)
+                                    long_prompts=self.do_long_prompts,
+                                ).to(self.device_torch, dtype=dtype)
                                 if isinstance(self.adapter, CustomAdapter):
                                     self.adapter.is_unconditional_run = False
-                            
+
                             if self.train_config.diff_output_preservation:
-                                dop_prompts = [p.replace(self.trigger_word, self.train_config.diff_output_preservation_class) for p in conditioned_prompts]
+                                dop_prompts = [
+                                    p.replace(
+                                        self.trigger_word,
+                                        self.train_config.diff_output_preservation_class,
+                                    )
+                                    for p in conditioned_prompts
+                                ]
                                 dop_prompts_2 = None
                                 if prompt_2 is not None:
-                                    dop_prompts_2 = [p.replace(self.trigger_word, self.train_config.diff_output_preservation_class) for p in prompt_2]
+                                    dop_prompts_2 = [
+                                        p.replace(
+                                            self.trigger_word,
+                                            self.train_config.diff_output_preservation_class,
+                                        )
+                                        for p in prompt_2
+                                    ]
                                 self.diff_output_preservation_embeds = self.sd.encode_prompt(
-                                    dop_prompts, dop_prompts_2,
+                                    dop_prompts,
+                                    dop_prompts_2,
                                     dropout_prob=self.train_config.prompt_dropout_prob,
-                                    long_prompts=self.do_long_prompts).to(
-                                    self.device_torch,
-                                    dtype=dtype)
+                                    long_prompts=self.do_long_prompts,
+                                ).to(
+                                    self.device_torch, dtype=dtype
+                                )
                         # detach the embeddings
                         conditional_embeds = conditional_embeds.detach()
                         if self.train_config.do_cfg:
                             unconditional_embeds = unconditional_embeds.detach()
-                    
+
                     if self.decorator:
                         conditional_embeds.text_embeds = self.decorator(
                             conditional_embeds.text_embeds
                         )
                         if self.train_config.do_cfg:
                             unconditional_embeds.text_embeds = self.decorator(
-                                unconditional_embeds.text_embeds, 
-                                is_unconditional=True
+                                unconditional_embeds.text_embeds, is_unconditional=True
                             )
 
                 # flush()
@@ -1491,28 +1771,39 @@ class SDTrainer(BaseSDTrainProcess):
 
                 if has_adapter_img:
                     if (self.adapter and isinstance(self.adapter, T2IAdapter)) or (
-                            self.assistant_adapter and isinstance(self.assistant_adapter, T2IAdapter)):
+                        self.assistant_adapter
+                        and isinstance(self.assistant_adapter, T2IAdapter)
+                    ):
                         with torch.set_grad_enabled(self.adapter is not None):
-                            adapter = self.assistant_adapter if self.assistant_adapter is not None else self.adapter
+                            adapter = (
+                                self.assistant_adapter
+                                if self.assistant_adapter is not None
+                                else self.adapter
+                            )
                             adapter_multiplier = get_adapter_multiplier()
-                            with self.timer('encode_adapter'):
-                                down_block_additional_residuals = adapter(adapter_images)
+                            with self.timer("encode_adapter"):
+                                down_block_additional_residuals = adapter(
+                                    adapter_images
+                                )
                                 if self.assistant_adapter:
                                     # not training. detach
                                     down_block_additional_residuals = [
-                                        sample.to(dtype=dtype).detach() * adapter_multiplier for sample in
-                                        down_block_additional_residuals
+                                        sample.to(dtype=dtype).detach()
+                                        * adapter_multiplier
+                                        for sample in down_block_additional_residuals
                                     ]
                                 else:
                                     down_block_additional_residuals = [
-                                        sample.to(dtype=dtype) * adapter_multiplier for sample in
-                                        down_block_additional_residuals
+                                        sample.to(dtype=dtype) * adapter_multiplier
+                                        for sample in down_block_additional_residuals
                                     ]
 
-                                pred_kwargs['down_intrablock_additional_residuals'] = down_block_additional_residuals
+                                pred_kwargs["down_intrablock_additional_residuals"] = (
+                                    down_block_additional_residuals
+                                )
 
                 if self.adapter and isinstance(self.adapter, IPAdapter):
-                    with self.timer('encode_adapter_embeds'):
+                    with self.timer("encode_adapter_embeds"):
                         # number of images to do if doing a quad image
                         quad_count = random.randint(1, 4)
                         image_size = self.adapter.input_size
@@ -1521,58 +1812,82 @@ class SDTrainer(BaseSDTrainProcess):
                             if is_reg:
                                 # get unconditional image embeds from cache
                                 embeds = [
-                                    load_file(random.choice(batch.clip_image_embeds_unconditional)) for i in
-                                    range(noisy_latents.shape[0])
+                                    load_file(
+                                        random.choice(
+                                            batch.clip_image_embeds_unconditional
+                                        )
+                                    )
+                                    for i in range(noisy_latents.shape[0])
                                 ]
-                                conditional_clip_embeds = self.adapter.parse_clip_image_embeds_from_cache(
-                                    embeds,
-                                    quad_count=quad_count
+                                conditional_clip_embeds = (
+                                    self.adapter.parse_clip_image_embeds_from_cache(
+                                        embeds, quad_count=quad_count
+                                    )
                                 )
 
                                 if self.train_config.do_cfg:
                                     embeds = [
-                                        load_file(random.choice(batch.clip_image_embeds_unconditional)) for i in
-                                        range(noisy_latents.shape[0])
+                                        load_file(
+                                            random.choice(
+                                                batch.clip_image_embeds_unconditional
+                                            )
+                                        )
+                                        for i in range(noisy_latents.shape[0])
                                     ]
-                                    unconditional_clip_embeds = self.adapter.parse_clip_image_embeds_from_cache(
-                                        embeds,
-                                        quad_count=quad_count
+                                    unconditional_clip_embeds = (
+                                        self.adapter.parse_clip_image_embeds_from_cache(
+                                            embeds, quad_count=quad_count
+                                        )
                                     )
 
                             else:
-                                conditional_clip_embeds = self.adapter.parse_clip_image_embeds_from_cache(
-                                    batch.clip_image_embeds,
-                                    quad_count=quad_count
+                                conditional_clip_embeds = (
+                                    self.adapter.parse_clip_image_embeds_from_cache(
+                                        batch.clip_image_embeds, quad_count=quad_count
+                                    )
                                 )
                                 if self.train_config.do_cfg:
-                                    unconditional_clip_embeds = self.adapter.parse_clip_image_embeds_from_cache(
-                                        batch.clip_image_embeds_unconditional,
-                                        quad_count=quad_count
+                                    unconditional_clip_embeds = (
+                                        self.adapter.parse_clip_image_embeds_from_cache(
+                                            batch.clip_image_embeds_unconditional,
+                                            quad_count=quad_count,
+                                        )
                                     )
                         elif is_reg:
                             # we will zero it out in the img embedder
                             clip_images = torch.zeros(
                                 (noisy_latents.shape[0], 3, image_size, image_size),
-                                device=self.device_torch, dtype=dtype
+                                device=self.device_torch,
+                                dtype=dtype,
                             ).detach()
                             # drop will zero it out
-                            conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                                clip_images,
-                                drop=True,
-                                is_training=True,
-                                has_been_preprocessed=False,
-                                quad_count=quad_count
+                            conditional_clip_embeds = (
+                                self.adapter.get_clip_image_embeds_from_tensors(
+                                    clip_images,
+                                    drop=True,
+                                    is_training=True,
+                                    has_been_preprocessed=False,
+                                    quad_count=quad_count,
+                                )
                             )
                             if self.train_config.do_cfg:
-                                unconditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                                    torch.zeros(
-                                        (noisy_latents.shape[0], 3, image_size, image_size),
-                                        device=self.device_torch, dtype=dtype
-                                    ).detach(),
-                                    is_training=True,
-                                    drop=True,
-                                    has_been_preprocessed=False,
-                                    quad_count=quad_count
+                                unconditional_clip_embeds = (
+                                    self.adapter.get_clip_image_embeds_from_tensors(
+                                        torch.zeros(
+                                            (
+                                                noisy_latents.shape[0],
+                                                3,
+                                                image_size,
+                                                image_size,
+                                            ),
+                                            device=self.device_torch,
+                                            dtype=dtype,
+                                        ).detach(),
+                                        is_training=True,
+                                        drop=True,
+                                        has_been_preprocessed=False,
+                                        quad_count=quad_count,
+                                    )
                                 )
                         elif has_clip_image:
                             conditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
@@ -1585,36 +1900,44 @@ class SDTrainer(BaseSDTrainProcess):
                                 # cfg_embed_strength=3.0 if not self.train_config.do_cfg else None
                             )
                             if self.train_config.do_cfg:
-                                unconditional_clip_embeds = self.adapter.get_clip_image_embeds_from_tensors(
-                                    clip_images.detach().to(self.device_torch, dtype=dtype),
-                                    is_training=True,
-                                    drop=True,
-                                    has_been_preprocessed=True,
-                                    quad_count=quad_count
+                                unconditional_clip_embeds = (
+                                    self.adapter.get_clip_image_embeds_from_tensors(
+                                        clip_images.detach().to(
+                                            self.device_torch, dtype=dtype
+                                        ),
+                                        is_training=True,
+                                        drop=True,
+                                        has_been_preprocessed=True,
+                                        quad_count=quad_count,
+                                    )
                                 )
                         else:
                             print_acc("No Clip Image")
-                            print_acc([file_item.path for file_item in batch.file_items])
+                            print_acc(
+                                [file_item.path for file_item in batch.file_items]
+                            )
                             raise ValueError("Could not find clip image")
 
                     if not self.adapter_config.train_image_encoder:
                         # we are not training the image encoder, so we need to detach the embeds
                         conditional_clip_embeds = conditional_clip_embeds.detach()
                         if self.train_config.do_cfg:
-                            unconditional_clip_embeds = unconditional_clip_embeds.detach()
+                            unconditional_clip_embeds = (
+                                unconditional_clip_embeds.detach()
+                            )
 
-                    with self.timer('encode_adapter'):
+                    with self.timer("encode_adapter"):
                         self.adapter.train()
                         conditional_embeds = self.adapter(
                             conditional_embeds.detach(),
                             conditional_clip_embeds,
-                            is_unconditional=False
+                            is_unconditional=False,
                         )
                         if self.train_config.do_cfg:
                             unconditional_embeds = self.adapter(
                                 unconditional_embeds.detach(),
                                 unconditional_clip_embeds,
-                                is_unconditional=True
+                                is_unconditional=True,
                             )
                         else:
                             # wipe out unconsitional
@@ -1626,7 +1949,11 @@ class SDTrainer(BaseSDTrainProcess):
                     if has_clip_image or has_adapter_img:
                         img_to_use = clip_images if has_clip_image else adapter_images
                         # currently 0-1 needs to be -1 to 1
-                        reference_images = ((img_to_use - 0.5) * 2).detach().to(self.device_torch, dtype=dtype)
+                        reference_images = (
+                            ((img_to_use - 0.5) * 2)
+                            .detach()
+                            .to(self.device_torch, dtype=dtype)
+                        )
                         self.adapter.set_reference_images(reference_images)
                         self.adapter.noise_scheduler = self.sd.noise_scheduler
                     elif is_reg:
@@ -1642,7 +1969,10 @@ class SDTrainer(BaseSDTrainProcess):
                 #     do_reg_prior = True
 
                 do_inverted_masked_prior = False
-                if self.train_config.inverted_mask_prior and batch.mask_tensor is not None:
+                if (
+                    self.train_config.inverted_mask_prior
+                    and batch.mask_tensor is not None
+                ):
                     do_inverted_masked_prior = True
 
                 do_correct_pred_norm_prior = self.train_config.correct_pred_norm
@@ -1651,18 +1981,34 @@ class SDTrainer(BaseSDTrainProcess):
 
                 if batch.unconditional_latents is not None:
                     # for this not that, we need a prior pred to normalize
-                    guidance_type: GuidanceType = batch.file_items[0].dataset_config.guidance_type
-                    if guidance_type == 'tnt':
+                    guidance_type: GuidanceType = batch.file_items[
+                        0
+                    ].dataset_config.guidance_type
+                    if guidance_type == "tnt":
                         do_guidance_prior = True
 
-                if ((
-                        has_adapter_img and self.assistant_adapter and match_adapter_assist) or self.do_prior_prediction or do_guidance_prior or do_reg_prior or do_inverted_masked_prior or self.train_config.correct_pred_norm):
-                    with self.timer('prior predict'):
+                if (
+                    (
+                        has_adapter_img
+                        and self.assistant_adapter
+                        and match_adapter_assist
+                    )
+                    or self.do_prior_prediction
+                    or do_guidance_prior
+                    or do_reg_prior
+                    or do_inverted_masked_prior
+                    or self.train_config.correct_pred_norm
+                ):
+                    with self.timer("prior predict"):
                         prior_embeds_to_use = conditional_embeds
                         # use diff_output_preservation embeds if doing dfe
                         if self.train_config.diff_output_preservation:
-                            prior_embeds_to_use = self.diff_output_preservation_embeds.expand_to_batch(noisy_latents.shape[0])
-                        
+                            prior_embeds_to_use = (
+                                self.diff_output_preservation_embeds.expand_to_batch(
+                                    noisy_latents.shape[0]
+                                )
+                            )
+
                         prior_pred = self.get_prior_prediction(
                             noisy_latents=noisy_latents,
                             conditional_embeds=prior_embeds_to_use,
@@ -1673,13 +2019,20 @@ class SDTrainer(BaseSDTrainProcess):
                             noise=noise,
                             batch=batch,
                             unconditional_embeds=unconditional_embeds,
-                            conditioned_prompts=conditioned_prompts
+                            conditioned_prompts=conditioned_prompts,
                         )
                         if prior_pred is not None:
                             prior_pred = prior_pred.detach()
 
                 # do the custom adapter after the prior prediction
-                if self.adapter and isinstance(self.adapter, CustomAdapter) and (has_clip_image or self.adapter_config.type in ['llm_adapter', 'text_encoder']):
+                if (
+                    self.adapter
+                    and isinstance(self.adapter, CustomAdapter)
+                    and (
+                        has_clip_image
+                        or self.adapter_config.type in ["llm_adapter", "text_encoder"]
+                    )
+                ):
                     quad_count = random.randint(1, 4)
                     self.adapter.train()
                     conditional_embeds = self.adapter.condition_encoded_embeds(
@@ -1687,7 +2040,7 @@ class SDTrainer(BaseSDTrainProcess):
                         prompt_embeds=conditional_embeds,
                         is_training=True,
                         has_been_preprocessed=True,
-                        quad_count=quad_count
+                        quad_count=quad_count,
                     )
                     if self.train_config.do_cfg and unconditional_embeds is not None:
                         unconditional_embeds = self.adapter.condition_encoded_embeds(
@@ -1696,30 +2049,48 @@ class SDTrainer(BaseSDTrainProcess):
                             is_training=True,
                             has_been_preprocessed=True,
                             is_unconditional=True,
-                            quad_count=quad_count
+                            quad_count=quad_count,
                         )
 
-                if self.adapter and isinstance(self.adapter, CustomAdapter) and batch.extra_values is not None:
+                if (
+                    self.adapter
+                    and isinstance(self.adapter, CustomAdapter)
+                    and batch.extra_values is not None
+                ):
                     self.adapter.add_extra_values(batch.extra_values.detach())
 
                     if self.train_config.do_cfg:
-                        self.adapter.add_extra_values(torch.zeros_like(batch.extra_values.detach()),
-                                                      is_unconditional=True)
+                        self.adapter.add_extra_values(
+                            torch.zeros_like(batch.extra_values.detach()),
+                            is_unconditional=True,
+                        )
 
                 if has_adapter_img:
                     if (self.adapter and isinstance(self.adapter, ControlNetModel)) or (
-                            self.assistant_adapter and isinstance(self.assistant_adapter, ControlNetModel)):
+                        self.assistant_adapter
+                        and isinstance(self.assistant_adapter, ControlNetModel)
+                    ):
                         if self.train_config.do_cfg:
-                            raise ValueError("ControlNetModel is not supported with CFG")
+                            raise ValueError(
+                                "ControlNetModel is not supported with CFG"
+                            )
                         with torch.set_grad_enabled(self.adapter is not None):
-                            adapter: ControlNetModel = self.assistant_adapter if self.assistant_adapter is not None else self.adapter
+                            adapter: ControlNetModel = (
+                                self.assistant_adapter
+                                if self.assistant_adapter is not None
+                                else self.adapter
+                            )
                             adapter_multiplier = get_adapter_multiplier()
-                            with self.timer('encode_adapter'):
+                            with self.timer("encode_adapter"):
                                 # add_text_embeds is pooled_prompt_embeds for sdxl
                                 added_cond_kwargs = {}
                                 if self.sd.is_xl:
-                                    added_cond_kwargs["text_embeds"] = conditional_embeds.pooled_embeds
-                                    added_cond_kwargs['time_ids'] = self.sd.get_time_ids_from_latents(noisy_latents)
+                                    added_cond_kwargs["text_embeds"] = (
+                                        conditional_embeds.pooled_embeds
+                                    )
+                                    added_cond_kwargs["time_ids"] = (
+                                        self.sd.get_time_ids_from_latents(noisy_latents)
+                                    )
                                 down_block_res_samples, mid_block_res_sample = adapter(
                                     noisy_latents,
                                     timesteps,
@@ -1730,54 +2101,83 @@ class SDTrainer(BaseSDTrainProcess):
                                     added_cond_kwargs=added_cond_kwargs,
                                     return_dict=False,
                                 )
-                                pred_kwargs['down_block_additional_residuals'] = down_block_res_samples
-                                pred_kwargs['mid_block_additional_residual'] = mid_block_res_sample
+                                pred_kwargs["down_block_additional_residuals"] = (
+                                    down_block_res_samples
+                                )
+                                pred_kwargs["mid_block_additional_residual"] = (
+                                    mid_block_res_sample
+                                )
 
                 self.before_unet_predict()
-                
+
                 if unconditional_embeds is not None:
-                    unconditional_embeds = unconditional_embeds.to(self.device_torch, dtype=dtype).detach()
-                with self.timer('condition_noisy_latents'):
+                    unconditional_embeds = unconditional_embeds.to(
+                        self.device_torch, dtype=dtype
+                    ).detach()
+                with self.timer("condition_noisy_latents"):
                     # do it for the model
-                    noisy_latents = self.sd.condition_noisy_latents(noisy_latents, batch)
+                    noisy_latents = self.sd.condition_noisy_latents(
+                        noisy_latents, batch
+                    )
                     if self.adapter and isinstance(self.adapter, CustomAdapter):
-                        noisy_latents = self.adapter.condition_noisy_latents(noisy_latents, batch)
-                
-                if self.train_config.timestep_type == 'next_sample':
-                    with self.timer('next_sample_step'):
+                        noisy_latents = self.adapter.condition_noisy_latents(
+                            noisy_latents, batch
+                        )
+
+                if self.train_config.timestep_type == "next_sample":
+                    with self.timer("next_sample_step"):
                         with torch.no_grad():
-                            
-                            stepped_timestep_indicies = [self.sd.noise_scheduler.index_for_timestep(t) + 1 for t in timesteps]
-                            stepped_timesteps = [self.sd.noise_scheduler.timesteps[x] for x in stepped_timestep_indicies]
+
+                            stepped_timestep_indicies = [
+                                self.sd.noise_scheduler.index_for_timestep(t) + 1
+                                for t in timesteps
+                            ]
+                            stepped_timesteps = [
+                                self.sd.noise_scheduler.timesteps[x]
+                                for x in stepped_timestep_indicies
+                            ]
                             stepped_timesteps = torch.stack(stepped_timesteps, dim=0)
-                            
+
                             # do a sample at the current timestep and step it, then determine new noise
                             next_sample_pred = self.predict_noise(
-                                noisy_latents=noisy_latents.to(self.device_torch, dtype=dtype),
+                                noisy_latents=noisy_latents.to(
+                                    self.device_torch, dtype=dtype
+                                ),
                                 timesteps=timesteps,
-                                conditional_embeds=conditional_embeds.to(self.device_torch, dtype=dtype),
+                                conditional_embeds=conditional_embeds.to(
+                                    self.device_torch, dtype=dtype
+                                ),
                                 unconditional_embeds=unconditional_embeds,
                                 batch=batch,
-                                **pred_kwargs
+                                **pred_kwargs,
                             )
                             stepped_latents = self.sd.step_scheduler(
                                 next_sample_pred,
                                 noisy_latents,
                                 timesteps,
-                                self.sd.noise_scheduler
+                                self.sd.noise_scheduler,
                             )
                             # stepped latents is our new noisy latents. Now we need to determine noise in the current sample
                             noisy_latents = stepped_latents
-                            original_samples = batch.latents.to(self.device_torch, dtype=dtype)
+                            original_samples = batch.latents.to(
+                                self.device_torch, dtype=dtype
+                            )
                             # todo calc next timestep, for now this may work as it
-                            t_01 = (stepped_timesteps / 1000).to(original_samples.device)
+                            t_01 = (stepped_timesteps / 1000).to(
+                                original_samples.device
+                            )
                             if len(stepped_latents.shape) == 4:
                                 t_01 = t_01.view(-1, 1, 1, 1)
                             elif len(stepped_latents.shape) == 5:
                                 t_01 = t_01.view(-1, 1, 1, 1, 1)
                             else:
-                                raise ValueError("Unknown stepped latents shape", stepped_latents.shape)
-                            next_sample_noise = (stepped_latents - (1.0 - t_01) * original_samples) / t_01
+                                raise ValueError(
+                                    "Unknown stepped latents shape",
+                                    stepped_latents.shape,
+                                )
+                            next_sample_noise = (
+                                stepped_latents - (1.0 - t_01) * original_samples
+                            ) / t_01
                             noise = next_sample_noise
                             timesteps = stepped_timesteps
                 # do a prior pred if we have an unconditional image, we will swap out the giadance later
@@ -1796,8 +2196,8 @@ class SDTrainer(BaseSDTrainProcess):
                         mask_multiplier=mask_multiplier,
                         prior_pred=prior_pred,
                     )
-                    
-                elif self.train_config.loss_type == 'mean_flow':
+
+                elif self.train_config.loss_type == "mean_flow":
                     loss = self.get_mean_flow_loss(
                         noisy_latents=noisy_latents,
                         conditional_embeds=conditional_embeds,
@@ -1811,27 +2211,34 @@ class SDTrainer(BaseSDTrainProcess):
                         prior_pred=prior_pred,
                     )
                 else:
-                    with self.timer('predict_unet'):
+                    with self.timer("predict_unet"):
                         noise_pred = self.predict_noise(
-                            noisy_latents=noisy_latents.to(self.device_torch, dtype=dtype),
+                            noisy_latents=noisy_latents.to(
+                                self.device_torch, dtype=dtype
+                            ),
                             timesteps=timesteps,
-                            conditional_embeds=conditional_embeds.to(self.device_torch, dtype=dtype),
+                            conditional_embeds=conditional_embeds.to(
+                                self.device_torch, dtype=dtype
+                            ),
                             unconditional_embeds=unconditional_embeds,
                             batch=batch,
                             is_primary_pred=True,
-                            **pred_kwargs
+                            **pred_kwargs,
                         )
                     self.after_unet_predict()
 
-                    with self.timer('calculate_loss'):
+                    with self.timer("calculate_loss"):
                         noise = noise.to(self.device_torch, dtype=dtype).detach()
                         prior_to_calculate_loss = prior_pred
                         # if we are doing diff_output_preservation and not noing inverted masked prior
                         # then we need to send none here so it will not target the prior
-                        if self.train_config.diff_output_preservation and not do_inverted_masked_prior:
+                        if (
+                            self.train_config.diff_output_preservation
+                            and not do_inverted_masked_prior
+                        ):
                             prior_to_calculate_loss = None
-                        
-                        if self.train_config.loss_type == 'cfm':
+
+                        if self.train_config.loss_type == "cfm":
                             loss = self.get_cfm_loss(
                                 noisy_latents=noisy_latents,
                                 noise=noise,
@@ -1850,35 +2257,46 @@ class SDTrainer(BaseSDTrainProcess):
                                 mask_multiplier=mask_multiplier,
                                 prior_pred=prior_to_calculate_loss,
                             )
-                    
+
                     if self.train_config.diff_output_preservation:
                         # send the loss backwards otherwise checkpointing will fail
                         self.accelerator.backward(loss)
-                        normal_loss = loss.detach() # dont send backward again
-                        
-                        dop_embeds = self.diff_output_preservation_embeds.expand_to_batch(noisy_latents.shape[0])
+                        normal_loss = loss.detach()  # dont send backward again
+
+                        dop_embeds = (
+                            self.diff_output_preservation_embeds.expand_to_batch(
+                                noisy_latents.shape[0]
+                            )
+                        )
                         dop_pred = self.predict_noise(
-                            noisy_latents=noisy_latents.to(self.device_torch, dtype=dtype),
+                            noisy_latents=noisy_latents.to(
+                                self.device_torch, dtype=dtype
+                            ),
                             timesteps=timesteps,
-                            conditional_embeds=dop_embeds.to(self.device_torch, dtype=dtype),
+                            conditional_embeds=dop_embeds.to(
+                                self.device_torch, dtype=dtype
+                            ),
                             unconditional_embeds=unconditional_embeds,
                             batch=batch,
-                            **pred_kwargs
+                            **pred_kwargs,
                         )
-                        dop_loss = torch.nn.functional.mse_loss(dop_pred, prior_pred) * self.train_config.diff_output_preservation_multiplier
+                        dop_loss = (
+                            torch.nn.functional.mse_loss(dop_pred, prior_pred)
+                            * self.train_config.diff_output_preservation_multiplier
+                        )
                         self.accelerator.backward(dop_loss)
-                        
+
                         loss = normal_loss + dop_loss
                         loss = loss.clone().detach()
                         # require grad again so the backward wont fail
                         loss.requires_grad_(True)
-                        
+
                 # check if nan
                 if torch.isnan(loss):
                     print_acc("loss is nan")
                     loss = torch.zeros_like(loss).requires_grad_(True)
 
-                with self.timer('backward'):
+                with self.timer("backward"):
                     # todo we have multiplier seperated. works for now as res are not in same batch, but need to change
                     loss = loss * loss_multiplier.mean()
                     # IMPORTANT if gradient checkpointing do not leave with network when doing backward
@@ -1895,7 +2313,9 @@ class SDTrainer(BaseSDTrainProcess):
         return loss.detach()
         # flush()
 
-    def hook_train_loop(self, batch: Union[DataLoaderBatchDTO, List[DataLoaderBatchDTO]]):
+    def hook_train_loop(
+        self, batch: Union[DataLoaderBatchDTO, List[DataLoaderBatchDTO]]
+    ):
         if isinstance(batch, list):
             batch_list = batch
         else:
@@ -1911,46 +2331,124 @@ class SDTrainer(BaseSDTrainProcess):
             if len(batch_list) > 1 and self.model_config.low_vram:
                 torch.cuda.empty_cache()
 
-
         if not self.is_grad_accumulation_step:
             # fix this for multi params
-            if self.train_config.optimizer != 'adafactor':
+            if self.train_config.optimizer != "adafactor":
                 if isinstance(self.params[0], dict):
                     for i in range(len(self.params)):
-                        self.accelerator.clip_grad_norm_(self.params[i]['params'], self.train_config.max_grad_norm)
+                        self.accelerator.clip_grad_norm_(
+                            self.params[i]["params"], self.train_config.max_grad_norm
+                        )
                 else:
-                    self.accelerator.clip_grad_norm_(self.params, self.train_config.max_grad_norm)
+                    self.accelerator.clip_grad_norm_(
+                        self.params, self.train_config.max_grad_norm
+                    )
             # only step if we are not accumulating
-            with self.timer('optimizer_step'):
+            with self.timer("optimizer_step"):
                 self.optimizer.step()
 
                 self.optimizer.zero_grad(set_to_none=True)
                 if self.adapter and isinstance(self.adapter, CustomAdapter):
                     self.adapter.post_weight_update()
             if self.ema is not None:
-                with self.timer('ema_update'):
+                with self.timer("ema_update"):
                     self.ema.update()
         else:
             # gradient accumulation. Just a place for breakpoint
             pass
 
         # TODO Should we only step scheduler on grad step? If so, need to recalculate last step
-        with self.timer('scheduler_step'):
+        with self.timer("scheduler_step"):
             self.lr_scheduler.step()
 
         if self.embedding is not None:
-            with self.timer('restore_embeddings'):
+            with self.timer("restore_embeddings"):
                 # Let's make sure we don't update any embedding weights besides the newly added token
                 self.embedding.restore_embeddings()
         if self.adapter is not None and isinstance(self.adapter, ClipVisionAdapter):
-            with self.timer('restore_adapter'):
+            with self.timer("restore_adapter"):
                 # Let's make sure we don't update any embedding weights besides the newly added token
                 self.adapter.restore_embeddings()
 
-        loss_dict = OrderedDict(
-            {'loss': loss.item()}
-        )
+        loss_dict = OrderedDict({"loss": loss.item()})
+
+        if (
+            self.train_config.validation_every is not None
+            and self.step_num % self.train_config.validation_every == 0
+        ):
+            validation_loss = self.hook_validation_loop(self.data_loader_val)
+            loss_dict["validation_loss"] = validation_loss.item()
 
         self.end_of_training_loop()
 
         return loss_dict
+
+    def hook_validation_loop(
+        self, batch: Union[DataLoaderBatchDTO, List[DataLoaderBatchDTO], DataLoader]
+    ):
+        """
+        Validation loop that evaluates model performance without updating weights.
+        Similar to training but with no gradient calculations or optimizer steps.
+        """
+        if isinstance(batch, DataLoader):
+            try:
+                batch_list = [next(iter(batch))]
+            except StopIteration:
+                return torch.tensor(0.0)
+        elif isinstance(batch, list):
+            batch_list = batch
+        else:
+            batch_list = [batch]
+
+        total_loss = None
+
+        # Ensure model components are in eval mode
+        if self.network is not None:
+            self.network.eval()
+        if self.adapter is not None:
+            self.adapter.eval()
+        if self.sd.unet is not None:
+            self.sd.unet.eval()
+
+        with torch.no_grad():
+            for batch in batch_list:
+                # Preprocess batch and get required tensors
+                batch = self.preprocess_batch(batch)
+                dtype = get_torch_dtype(self.train_config.dtype)
+
+                noisy_latents, noise, timesteps, conditioned_prompts, imgs = (
+                    self.process_general_training_batch(batch)
+                )
+
+                conditional_embeds = self.sd.encode_prompt(
+                    conditioned_prompts, long_prompts=self.do_long_prompts
+                ).to(self.device_torch, dtype=dtype)
+
+                noise_pred = self.predict_noise(
+                    noisy_latents=noisy_latents,
+                    timesteps=timesteps,
+                    conditional_embeds=conditional_embeds,
+                )
+
+                loss = self.calculate_loss(
+                    noise_pred=noise_pred,
+                    noise=noise,
+                    noisy_latents=noisy_latents,
+                    timesteps=timesteps,
+                    batch=batch,
+                )
+
+                if total_loss is None:
+                    total_loss = loss
+                else:
+                    total_loss += loss
+
+        # Restore training mode
+        if self.network is not None:
+            self.network.train()
+        if self.adapter is not None:
+            self.adapter.train()
+        if self.sd.unet is not None:
+            self.sd.unet.train()
+
+        return total_loss.detach()

--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -15,6 +15,7 @@ import yaml
 from diffusers import T2IAdapter, ControlNetModel
 from diffusers.training_utils import compute_density_for_timestep_sampling
 from safetensors.torch import save_file, load_file
+
 # from lycoris.config import PRESET
 from torch.utils.data import DataLoader
 import torch
@@ -25,15 +26,24 @@ from huggingface_hub.utils import HfFolder
 from toolkit.basic import value_map
 from toolkit.clip_vision_adapter import ClipVisionAdapter
 from toolkit.custom_adapter import CustomAdapter
-from toolkit.data_loader import get_dataloader_from_datasets, trigger_dataloader_setup_epoch
+from toolkit.data_loader import (
+    get_dataloader_from_datasets,
+    trigger_dataloader_setup_epoch,
+)
 from toolkit.data_transfer_object.data_loader import FileItemDTO, DataLoaderBatchDTO
 from toolkit.ema import ExponentialMovingAverage
 from toolkit.embedding import Embedding
 from toolkit.image_utils import show_tensors, show_latents, reduce_contrast
 from toolkit.ip_adapter import IPAdapter
 from toolkit.lora_special import LoRASpecialNetwork
-from toolkit.lorm import convert_diffusers_unet_to_lorm, count_parameters, print_lorm_extract_details, \
-    lorm_ignore_if_contains, lorm_parameter_threshold, LORM_TARGET_REPLACE_MODULE
+from toolkit.lorm import (
+    convert_diffusers_unet_to_lorm,
+    count_parameters,
+    print_lorm_extract_details,
+    lorm_ignore_if_contains,
+    lorm_parameter_threshold,
+    LORM_TARGET_REPLACE_MODULE,
+)
 from toolkit.lycoris_special import LycorisSpecialNetwork
 from toolkit.models.decorator import Decorator
 from toolkit.network_mixins import Network
@@ -42,24 +52,51 @@ from toolkit.paths import CONFIG_ROOT
 from toolkit.progress_bar import ToolkitProgressBar
 from toolkit.reference_adapter import ReferenceAdapter
 from toolkit.sampler import get_sampler
-from toolkit.saving import save_t2i_from_diffusers, load_t2i_model, save_ip_adapter_from_diffusers, \
-    load_ip_adapter_model, load_custom_adapter_model
+from toolkit.saving import (
+    save_t2i_from_diffusers,
+    load_t2i_model,
+    save_ip_adapter_from_diffusers,
+    load_ip_adapter_model,
+    load_custom_adapter_model,
+)
 
 from toolkit.scheduler import get_lr_scheduler
 from toolkit.sd_device_states_presets import get_train_sd_device_state_preset
 from toolkit.stable_diffusion_model import StableDiffusion
 
 from jobs.process import BaseTrainProcess
-from toolkit.metadata import get_meta_for_safetensors, load_metadata_from_safetensors, add_base_model_info_to_meta, \
-    parse_metadata_from_safetensors
-from toolkit.train_tools import get_torch_dtype, LearnableSNRGamma, apply_learnable_snr_gos, apply_snr_weight
+from toolkit.metadata import (
+    get_meta_for_safetensors,
+    load_metadata_from_safetensors,
+    add_base_model_info_to_meta,
+    parse_metadata_from_safetensors,
+)
+from toolkit.train_tools import (
+    get_torch_dtype,
+    LearnableSNRGamma,
+    apply_learnable_snr_gos,
+    apply_snr_weight,
+)
 import gc
 
 from tqdm import tqdm
 
-from toolkit.config_modules import SaveConfig, LoggingConfig, SampleConfig, NetworkConfig, TrainConfig, ModelConfig, \
-    GenerateImageConfig, EmbeddingConfig, DatasetConfig, preprocess_dataset_raw_config, AdapterConfig, GuidanceConfig, validate_configs, \
-    DecoratorConfig
+from toolkit.config_modules import (
+    SaveConfig,
+    LoggingConfig,
+    SampleConfig,
+    NetworkConfig,
+    TrainConfig,
+    ModelConfig,
+    GenerateImageConfig,
+    EmbeddingConfig,
+    DatasetConfig,
+    preprocess_dataset_raw_config,
+    AdapterConfig,
+    GuidanceConfig,
+    validate_configs,
+    DecoratorConfig,
+)
 from toolkit.logging_aitk import create_logger
 from diffusers import FluxTransformer2DModel
 from toolkit.accelerator import get_accelerator, unwrap_model
@@ -71,6 +108,7 @@ import hashlib
 
 from toolkit.util.blended_blur_noise import get_blended_blur_noise
 from toolkit.util.get_model import get_model_class
+
 
 def flush():
     torch.cuda.empty_cache()
@@ -88,7 +126,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
         else:
             transformers.utils.logging.set_verbosity_error()
             diffusers.utils.logging.set_verbosity_error()
-        
+
         self.sd: StableDiffusion
         self.embedding: Union[Embedding, None] = None
 
@@ -103,44 +141,46 @@ class BaseSDTrainProcess(BaseTrainProcess):
         self.is_grad_accumulation_step = False
         self.device = str(self.accelerator.device)
         self.device_torch = self.accelerator.device
-        network_config = self.get_conf('network', None)
+        network_config = self.get_conf("network", None)
         if network_config is not None:
             self.network_config = NetworkConfig(**network_config)
         else:
             self.network_config = None
-        self.train_config = TrainConfig(**self.get_conf('train', {}))
-        model_config = self.get_conf('model', {})
+        self.train_config = TrainConfig(**self.get_conf("train", {}))
+        model_config = self.get_conf("model", {})
         self.modules_being_trained: List[torch.nn.Module] = []
 
         # update modelconfig dtype to match train
-        model_config['dtype'] = self.train_config.dtype
+        model_config["dtype"] = self.train_config.dtype
         self.model_config = ModelConfig(**model_config)
 
-        self.save_config = SaveConfig(**self.get_conf('save', {}))
-        self.sample_config = SampleConfig(**self.get_conf('sample', {}))
-        first_sample_config = self.get_conf('first_sample', None)
+        self.save_config = SaveConfig(**self.get_conf("save", {}))
+        self.sample_config = SampleConfig(**self.get_conf("sample", {}))
+        first_sample_config = self.get_conf("first_sample", None)
         if first_sample_config is not None:
             self.has_first_sample_requested = True
             self.first_sample_config = SampleConfig(**first_sample_config)
         else:
             self.has_first_sample_requested = False
             self.first_sample_config = self.sample_config
-        self.logging_config = LoggingConfig(**self.get_conf('logging', {}))
+        self.logging_config = LoggingConfig(**self.get_conf("logging", {}))
         self.logger = create_logger(self.logging_config, config)
         self.optimizer: torch.optim.Optimizer = None
         self.lr_scheduler = None
         self.data_loader: Union[DataLoader, None] = None
         self.data_loader_reg: Union[DataLoader, None] = None
-        self.trigger_word = self.get_conf('trigger_word', None)
+        self.data_loader_val: Union[DataLoader, None] = None
+        self.data_loader_val_reg: Union[DataLoader, None] = None
+        self.trigger_word = self.get_conf("trigger_word", None)
 
         self.guidance_config: Union[GuidanceConfig, None] = None
-        guidance_config_raw = self.get_conf('guidance', None)
+        guidance_config_raw = self.get_conf("guidance", None)
         if guidance_config_raw is not None:
             self.guidance_config = GuidanceConfig(**guidance_config_raw)
 
         # store is all are cached. Allows us to not load vae if we don't need to
         self.is_latents_cached = True
-        raw_datasets = self.get_conf('datasets', None)
+        raw_datasets = self.get_conf("datasets", None)
         if raw_datasets is not None and len(raw_datasets) > 0:
             raw_datasets = preprocess_dataset_raw_config(raw_datasets)
         self.datasets = None
@@ -162,37 +202,52 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     self.datasets.append(dataset)
 
         self.embed_config = None
-        embedding_raw = self.get_conf('embedding', None)
+        embedding_raw = self.get_conf("embedding", None)
         if embedding_raw is not None:
             self.embed_config = EmbeddingConfig(**embedding_raw)
-        
+
         self.decorator_config: DecoratorConfig = None
-        decorator_raw = self.get_conf('decorator', None)
+        decorator_raw = self.get_conf("decorator", None)
         if decorator_raw is not None:
             if not self.model_config.is_flux:
-                raise ValueError("Decorators are only supported for Flux models currently")
+                raise ValueError(
+                    "Decorators are only supported for Flux models currently"
+                )
             self.decorator_config = DecoratorConfig(**decorator_raw)
 
         # t2i adapter
         self.adapter_config = None
-        adapter_raw = self.get_conf('adapter', None)
+        adapter_raw = self.get_conf("adapter", None)
         if adapter_raw is not None:
             self.adapter_config = AdapterConfig(**adapter_raw)
             # sdxl adapters end in _xl. Only full_adapter_xl for now
-            if self.model_config.is_xl and not self.adapter_config.adapter_type.endswith('_xl'):
-                self.adapter_config.adapter_type += '_xl'
+            if (
+                self.model_config.is_xl
+                and not self.adapter_config.adapter_type.endswith("_xl")
+            ):
+                self.adapter_config.adapter_type += "_xl"
 
         # to hold network if there is one
         self.network: Union[Network, None] = None
-        self.adapter: Union[T2IAdapter, IPAdapter, ClipVisionAdapter, ReferenceAdapter, CustomAdapter, ControlNetModel, None] = None
+        self.adapter: Union[
+            T2IAdapter,
+            IPAdapter,
+            ClipVisionAdapter,
+            ReferenceAdapter,
+            CustomAdapter,
+            ControlNetModel,
+            None,
+        ] = None
         self.embedding: Union[Embedding, None] = None
         self.decorator: Union[Decorator, None] = None
 
-        is_training_adapter = self.adapter_config is not None and self.adapter_config.train
+        is_training_adapter = (
+            self.adapter_config is not None and self.adapter_config.train
+        )
 
-        self.do_lorm = self.get_conf('do_lorm', False)
-        self.lorm_extract_mode = self.get_conf('lorm_extract_mode', 'ratio')
-        self.lorm_extract_mode_param = self.get_conf('lorm_extract_mode_param', 0.25)
+        self.do_lorm = self.get_conf("do_lorm", False)
+        self.lorm_extract_mode = self.get_conf("lorm_extract_mode", "ratio")
+        self.lorm_extract_mode_param = self.get_conf("lorm_extract_mode_param", 0.25)
         # 'ratio', 0.25)
 
         # get the device state preset based on what we are training
@@ -207,9 +262,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
             train_decorator=self.decorator_config is not None,
             train_refiner=self.train_config.train_refiner,
             unload_text_encoder=self.train_config.unload_text_encoder,
-            require_grads=False  # we ensure them later
+            require_grads=False,  # we ensure them later
         )
-        
+
         self.get_params_device_state_preset = get_train_sd_device_state_preset(
             device=self.device_torch,
             train_unet=self.train_config.train_unet,
@@ -221,12 +276,17 @@ class BaseSDTrainProcess(BaseTrainProcess):
             train_decorator=self.decorator_config is not None,
             train_refiner=self.train_config.train_refiner,
             unload_text_encoder=self.train_config.unload_text_encoder,
-            require_grads=True  # We check for grads when getting params
+            require_grads=True,  # We check for grads when getting params
         )
 
         # fine_tuning here is for training actual SD network, not LoRA, embeddings, etc. it is (Dreambooth, etc)
         self.is_fine_tuning = True
-        if self.network_config is not None or is_training_adapter or self.embed_config is not None or self.decorator_config is not None:
+        if (
+            self.network_config is not None
+            or is_training_adapter
+            or self.embed_config is not None
+            or self.decorator_config is not None
+        ):
             self.is_fine_tuning = False
 
         self.named_lora = False
@@ -234,10 +294,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.named_lora = True
         self.snr_gos: Union[LearnableSNRGamma, None] = None
         self.ema: ExponentialMovingAverage = None
-        
+
+        self.validation_every = self.train_config.validation_every
+
         validate_configs(self.train_config, self.model_config, self.save_config)
 
-    def post_process_generate_image_config_list(self, generate_image_config_list: List[GenerateImageConfig]):
+    def post_process_generate_image_config_list(
+        self, generate_image_config_list: List[GenerateImageConfig]
+    ):
         # override in subclass
         return generate_image_config_list
 
@@ -245,7 +309,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
         if not self.accelerator.is_main_process:
             return
         flush()
-        sample_folder = os.path.join(self.save_root, 'samples')
+        sample_folder = os.path.join(self.save_root, "samples")
         gen_img_config_list = []
 
         sample_config = self.first_sample_config if is_first else self.sample_config
@@ -253,17 +317,22 @@ class BaseSDTrainProcess(BaseTrainProcess):
         current_seed = start_seed
 
         test_image_paths = []
-        if self.adapter_config is not None and self.adapter_config.test_img_path is not None:
+        if (
+            self.adapter_config is not None
+            and self.adapter_config.test_img_path is not None
+        ):
             test_image_path_list = self.adapter_config.test_img_path
             # divide up images so they are evenly distributed across prompts
             for i in range(len(sample_config.prompts)):
-                test_image_paths.append(test_image_path_list[i % len(test_image_path_list)])
+                test_image_paths.append(
+                    test_image_path_list[i % len(test_image_path_list)]
+                )
 
         for i in range(len(sample_config.prompts)):
             if sample_config.walk_seed:
                 current_seed = start_seed + i
 
-            step_num = ''
+            step_num = ""
             if step is not None:
                 # zero-pad 9 digits
                 step_num = f"_{str(step).zfill(9)}"
@@ -291,32 +360,39 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 )
 
             extra_args = {}
-            if self.adapter_config is not None and self.adapter_config.test_img_path is not None:
-                extra_args['adapter_image_path'] = test_image_paths[i]
+            if (
+                self.adapter_config is not None
+                and self.adapter_config.test_img_path is not None
+            ):
+                extra_args["adapter_image_path"] = test_image_paths[i]
 
-            gen_img_config_list.append(GenerateImageConfig(
-                prompt=prompt,  # it will autoparse the prompt
-                width=sample_config.width,
-                height=sample_config.height,
-                negative_prompt=sample_config.neg,
-                seed=current_seed,
-                guidance_scale=sample_config.guidance_scale,
-                guidance_rescale=sample_config.guidance_rescale,
-                num_inference_steps=sample_config.sample_steps,
-                network_multiplier=sample_config.network_multiplier,
-                output_path=output_path,
-                output_ext=sample_config.ext,
-                adapter_conditioning_scale=sample_config.adapter_conditioning_scale,
-                refiner_start_at=sample_config.refiner_start_at,
-                extra_values=sample_config.extra_values,
-                logger=self.logger,
-                num_frames=sample_config.num_frames,
-                fps=sample_config.fps,
-                **extra_args
-            ))
+            gen_img_config_list.append(
+                GenerateImageConfig(
+                    prompt=prompt,  # it will autoparse the prompt
+                    width=sample_config.width,
+                    height=sample_config.height,
+                    negative_prompt=sample_config.neg,
+                    seed=current_seed,
+                    guidance_scale=sample_config.guidance_scale,
+                    guidance_rescale=sample_config.guidance_rescale,
+                    num_inference_steps=sample_config.sample_steps,
+                    network_multiplier=sample_config.network_multiplier,
+                    output_path=output_path,
+                    output_ext=sample_config.ext,
+                    adapter_conditioning_scale=sample_config.adapter_conditioning_scale,
+                    refiner_start_at=sample_config.refiner_start_at,
+                    extra_values=sample_config.extra_values,
+                    logger=self.logger,
+                    num_frames=sample_config.num_frames,
+                    fps=sample_config.fps,
+                    **extra_args,
+                )
+            )
 
         # post process
-        gen_img_config_list = self.post_process_generate_image_config_list(gen_img_config_list)
+        gen_img_config_list = self.post_process_generate_image_config_list(
+            gen_img_config_list
+        )
 
         # if we have an ema, set it to validation mode
         if self.ema is not None:
@@ -325,11 +401,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # let adapter know we are sampling
         if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
             self.adapter.is_sampling = True
-        
+
         # send to be generated
         self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
 
-        
         if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
             self.adapter.is_sampling = False
 
@@ -337,33 +412,31 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.ema.train()
 
     def update_training_metadata(self):
-        o_dict = OrderedDict({
-            "training_info": self.get_training_info()
-        })
-        o_dict['ss_base_model_version'] = self.sd.get_base_model_version()
+        o_dict = OrderedDict({"training_info": self.get_training_info()})
+        o_dict["ss_base_model_version"] = self.sd.get_base_model_version()
 
         o_dict = add_base_model_info_to_meta(
             o_dict,
             is_v2=self.model_config.is_v2,
             is_xl=self.model_config.is_xl,
         )
-        o_dict['ss_output_name'] = self.job.name
+        o_dict["ss_output_name"] = self.job.name
 
         if self.trigger_word is not None:
             # just so auto1111 will pick it up
-            o_dict['ss_tag_frequency'] = {
-                f"1_{self.trigger_word}": {
-                    f"{self.trigger_word}": 1
-                }
+            o_dict["ss_tag_frequency"] = {
+                f"1_{self.trigger_word}": {f"{self.trigger_word}": 1}
             }
 
         self.add_meta(o_dict)
 
     def get_training_info(self):
-        info = OrderedDict({
-            'step': self.step_num,
-            'epoch': self.epoch_num,
-        })
+        info = OrderedDict(
+            {
+                "step": self.step_num,
+                "epoch": self.epoch_num,
+            }
+        )
         return info
 
     def clean_up_saves(self):
@@ -377,16 +450,22 @@ class BaseSDTrainProcess(BaseTrainProcess):
             pattern = f"{self.job.name}_*"
             items = glob.glob(os.path.join(self.save_root, pattern))
             # Separate files and directories
-            safetensors_files = [f for f in items if f.endswith('.safetensors')]
-            pt_files = [f for f in items if f.endswith('.pt')]
-            directories = [d for d in items if os.path.isdir(d) and not d.endswith('.safetensors')]
+            safetensors_files = [f for f in items if f.endswith(".safetensors")]
+            pt_files = [f for f in items if f.endswith(".pt")]
+            directories = [
+                d for d in items if os.path.isdir(d) and not d.endswith(".safetensors")
+            ]
             embed_files = []
             # do embedding files
             if self.embed_config is not None:
                 embed_pattern = f"{self.embed_config.trigger}_*"
                 embed_items = glob.glob(os.path.join(self.save_root, embed_pattern))
                 # will end in safetensors or pt
-                embed_files = [f for f in embed_items if f.endswith('.safetensors') or f.endswith('.pt')]
+                embed_files = [
+                    f
+                    for f in embed_items
+                    if f.endswith(".safetensors") or f.endswith(".pt")
+                ]
 
             # check for critic files
             critic_pattern = f"CRITIC_{self.job.name}_*"
@@ -409,14 +488,37 @@ class BaseSDTrainProcess(BaseTrainProcess):
             combined_items.sort(key=os.path.getctime)
 
             # Use slicing with a check to avoid 'NoneType' error
-            safetensors_to_remove = safetensors_files[
-                                    :-self.save_config.max_step_saves_to_keep] if safetensors_files else []
-            pt_files_to_remove = pt_files[:-self.save_config.max_step_saves_to_keep] if pt_files else []
-            directories_to_remove = directories[:-self.save_config.max_step_saves_to_keep] if directories else []
-            embeddings_to_remove = embed_files[:-self.save_config.max_step_saves_to_keep] if embed_files else []
-            critic_to_remove = critic_items[:-self.save_config.max_step_saves_to_keep] if critic_items else []
+            safetensors_to_remove = (
+                safetensors_files[: -self.save_config.max_step_saves_to_keep]
+                if safetensors_files
+                else []
+            )
+            pt_files_to_remove = (
+                pt_files[: -self.save_config.max_step_saves_to_keep] if pt_files else []
+            )
+            directories_to_remove = (
+                directories[: -self.save_config.max_step_saves_to_keep]
+                if directories
+                else []
+            )
+            embeddings_to_remove = (
+                embed_files[: -self.save_config.max_step_saves_to_keep]
+                if embed_files
+                else []
+            )
+            critic_to_remove = (
+                critic_items[: -self.save_config.max_step_saves_to_keep]
+                if critic_items
+                else []
+            )
 
-            items_to_remove = safetensors_to_remove + pt_files_to_remove + directories_to_remove + embeddings_to_remove + critic_to_remove
+            items_to_remove = (
+                safetensors_to_remove
+                + pt_files_to_remove
+                + directories_to_remove
+                + embeddings_to_remove
+                + critic_to_remove
+            )
 
             # remove all but the latest max_step_saves_to_keep
             # items_to_remove = combined_items[:-self.save_config.max_step_saves_to_keep]
@@ -441,10 +543,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
     def post_save_hook(self, save_path):
         # override in subclass
         pass
-    
+
     def done_hook(self):
         pass
-    
+
     def end_step_hook(self):
         pass
 
@@ -459,14 +561,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
         if not os.path.exists(self.save_root):
             os.makedirs(self.save_root, exist_ok=True)
 
-        step_num = ''
+        step_num = ""
         if step is not None:
             self.last_save_step = step
             # zeropad 9 digits
             step_num = f"_{str(step).zfill(9)}"
 
         self.update_training_metadata()
-        filename = f'{self.job.name}{step_num}.safetensors'
+        filename = f"{self.job.name}{step_num}.safetensors"
         file_path = os.path.join(self.save_root, filename)
 
         save_meta = copy.deepcopy(self.meta)
@@ -484,9 +586,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 lora_name = self.job.name
                 if self.named_lora:
                     # add _lora to name
-                    lora_name += '_LoRA'
+                    lora_name += "_LoRA"
 
-                filename = f'{lora_name}{step_num}.safetensors'
+                filename = f"{lora_name}{step_num}.safetensors"
                 file_path = os.path.join(self.save_root, filename)
                 prev_multiplier = self.network.multiplier
                 self.network.multiplier = 1.0
@@ -497,14 +599,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     file_path,
                     dtype=get_torch_dtype(self.save_config.dtype),
                     metadata=save_meta,
-                    extra_state_dict=embedding_dict
+                    extra_state_dict=embedding_dict,
                 )
                 self.network.multiplier = prev_multiplier
                 # if we have an embedding as well, pair it with the network
 
             # even if added to lora, still save the trigger version
             if self.embedding is not None:
-                emb_filename = f'{self.embed_config.trigger}{step_num}.safetensors'
+                emb_filename = f"{self.embed_config.trigger}{step_num}.safetensors"
                 emb_file_path = os.path.join(self.save_root, emb_filename)
                 # for combo, above will get it
                 # set current step
@@ -514,14 +616,16 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     # replace extension
                     emb_file_path = os.path.splitext(emb_file_path)[0] + ".pt"
                 self.embedding.save(emb_file_path)
-            
+
             if self.decorator is not None:
-                dec_filename = f'{self.job.name}{step_num}.safetensors'
+                dec_filename = f"{self.job.name}{step_num}.safetensors"
                 dec_file_path = os.path.join(self.save_root, dec_filename)
                 decorator_state_dict = self.decorator.state_dict()
                 for key, value in decorator_state_dict.items():
                     if isinstance(value, torch.Tensor):
-                        decorator_state_dict[key] = value.clone().to('cpu', dtype=get_torch_dtype(self.save_config.dtype))
+                        decorator_state_dict[key] = value.clone().to(
+                            "cpu", dtype=get_torch_dtype(self.save_config.dtype)
+                        )
                 save_file(
                     decorator_state_dict,
                     dec_file_path,
@@ -532,42 +636,45 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 adapter_name = self.job.name
                 if self.network_config is not None or self.embedding is not None:
                     # add _lora to name
-                    if self.adapter_config.type == 't2i':
-                        adapter_name += '_t2i'
-                    elif self.adapter_config.type == 'control_net':
-                        adapter_name += '_cn'
-                    elif self.adapter_config.type == 'clip':
-                        adapter_name += '_clip'
-                    elif self.adapter_config.type.startswith('ip'):
-                        adapter_name += '_ip'
+                    if self.adapter_config.type == "t2i":
+                        adapter_name += "_t2i"
+                    elif self.adapter_config.type == "control_net":
+                        adapter_name += "_cn"
+                    elif self.adapter_config.type == "clip":
+                        adapter_name += "_clip"
+                    elif self.adapter_config.type.startswith("ip"):
+                        adapter_name += "_ip"
                     else:
-                        adapter_name += '_adapter'
+                        adapter_name += "_adapter"
 
-                filename = f'{adapter_name}{step_num}.safetensors'
+                filename = f"{adapter_name}{step_num}.safetensors"
                 file_path = os.path.join(self.save_root, filename)
                 # save adapter
                 state_dict = self.adapter.state_dict()
-                if self.adapter_config.type == 't2i':
+                if self.adapter_config.type == "t2i":
                     save_t2i_from_diffusers(
                         state_dict,
                         output_file=file_path,
                         meta=save_meta,
-                        dtype=get_torch_dtype(self.save_config.dtype)
+                        dtype=get_torch_dtype(self.save_config.dtype),
                     )
-                elif self.adapter_config.type == 'control_net':
+                elif self.adapter_config.type == "control_net":
                     # save in diffusers format
-                    name_or_path = file_path.replace('.safetensors', '')
+                    name_or_path = file_path.replace(".safetensors", "")
                     # move it to the new dtype and cpu
                     orig_device = self.adapter.device
                     orig_dtype = self.adapter.dtype
-                    self.adapter = self.adapter.to(torch.device('cpu'), dtype=get_torch_dtype(self.save_config.dtype))
+                    self.adapter = self.adapter.to(
+                        torch.device("cpu"),
+                        dtype=get_torch_dtype(self.save_config.dtype),
+                    )
                     self.adapter.save_pretrained(
                         name_or_path,
                         dtype=get_torch_dtype(self.save_config.dtype),
-                        safe_serialization=True
+                        safe_serialization=True,
                     )
-                    meta_path = os.path.join(name_or_path, 'aitk_meta.yaml')
-                    with open(meta_path, 'w') as f:
+                    meta_path = os.path.join(name_or_path, "aitk_meta.yaml")
+                    with open(meta_path, "w") as f:
                         yaml.dump(self.meta, f)
                     # move it back
                     self.adapter = self.adapter.to(orig_device, dtype=orig_dtype)
@@ -575,59 +682,57 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     direct_save = False
                     if self.adapter_config.train_only_image_encoder:
                         direct_save = True
-                    if self.adapter_config.type == 'redux':
+                    if self.adapter_config.type == "redux":
                         direct_save = True
-                    if self.adapter_config.type in ['control_lora', 'subpixel', 'i2v']:
+                    if self.adapter_config.type in ["control_lora", "subpixel", "i2v"]:
                         direct_save = True
                     save_ip_adapter_from_diffusers(
                         state_dict,
                         output_file=file_path,
                         meta=save_meta,
                         dtype=get_torch_dtype(self.save_config.dtype),
-                        direct_save=direct_save
+                        direct_save=direct_save,
                     )
         else:
             if self.save_config.save_format == "diffusers":
                 # saving as a folder path
-                file_path = file_path.replace('.safetensors', '')
+                file_path = file_path.replace(".safetensors", "")
                 # convert it back to normal object
                 save_meta = parse_metadata_from_safetensors(save_meta)
 
             if self.sd.refiner_unet and self.train_config.train_refiner:
                 # save refiner
-                refiner_name = self.job.name + '_refiner'
-                filename = f'{refiner_name}{step_num}.safetensors'
+                refiner_name = self.job.name + "_refiner"
+                filename = f"{refiner_name}{step_num}.safetensors"
                 file_path = os.path.join(self.save_root, filename)
                 self.sd.save_refiner(
-                    file_path,
-                    save_meta,
-                    get_torch_dtype(self.save_config.dtype)
+                    file_path, save_meta, get_torch_dtype(self.save_config.dtype)
                 )
             if self.train_config.train_unet or self.train_config.train_text_encoder:
                 self.sd.save(
-                    file_path,
-                    save_meta,
-                    get_torch_dtype(self.save_config.dtype)
+                    file_path, save_meta, get_torch_dtype(self.save_config.dtype)
                 )
 
         # save learnable params as json if we have thim
         if self.snr_gos:
             json_data = {
-                'offset_1': self.snr_gos.offset_1.item(),
-                'offset_2': self.snr_gos.offset_2.item(),
-                'scale': self.snr_gos.scale.item(),
-                'gamma': self.snr_gos.gamma.item(),
+                "offset_1": self.snr_gos.offset_1.item(),
+                "offset_2": self.snr_gos.offset_2.item(),
+                "scale": self.snr_gos.scale.item(),
+                "gamma": self.snr_gos.gamma.item(),
             }
-            path_to_save = file_path = os.path.join(self.save_root, 'learnable_snr.json')
-            with open(path_to_save, 'w') as f:
+            path_to_save = file_path = os.path.join(
+                self.save_root, "learnable_snr.json"
+            )
+            with open(path_to_save, "w") as f:
                 json.dump(json_data, f, indent=4)
-        
+
         print_acc(f"Saved checkpoint to {file_path}")
 
         # save optimizer
         if self.optimizer is not None:
             try:
-                filename = f'optimizer.pt'
+                filename = f"optimizer.pt"
                 file_path = os.path.join(self.save_root, filename)
                 try:
                     state_dict = unwrap_model(self.optimizer).state_dict()
@@ -663,14 +768,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
         if self.accelerator.is_main_process:
             self.logger.start()
         self.prepare_accelerator()
-        
+
     def sample_step_hook(self, img_num, total_imgs):
         pass
-    
+
     def prepare_accelerator(self):
         # set some config
-        self.accelerator.even_batches=False
-        
+        self.accelerator.even_batches = False
+
         # # prepare all the models stuff for accelerator (hopefully we dont miss any)
         self.sd.vae = self.accelerator.prepare(self.sd.vae)
         if self.sd.unet is not None:
@@ -679,7 +784,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.modules_being_trained.append(self.sd.unet)
         if self.sd.text_encoder is not None and self.train_config.train_text_encoder:
             if isinstance(self.sd.text_encoder, list):
-                self.sd.text_encoder = [self.accelerator.prepare(model) for model in self.sd.text_encoder]
+                self.sd.text_encoder = [
+                    self.accelerator.prepare(model) for model in self.sd.text_encoder
+                ]
                 self.modules_being_trained.extend(self.sd.text_encoder)
             else:
                 self.sd.text_encoder = self.accelerator.prepare(self.sd.text_encoder)
@@ -695,7 +802,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             # todo adapters may not be a module. need to check
             self.adapter = self.accelerator.prepare(self.adapter)
             self.modules_being_trained.append(self.adapter)
-        
+
         # prepare other things
         self.optimizer = self.accelerator.prepare(self.optimizer)
         if self.lr_scheduler is not None:
@@ -703,15 +810,16 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # self.data_loader = self.accelerator.prepare(self.data_loader)
         # if self.data_loader_reg is not None:
         #     self.data_loader_reg = self.accelerator.prepare(self.data_loader_reg)
-            
 
     def ensure_params_requires_grad(self, force=False):
         if self.train_config.do_paramiter_swapping and not force:
             # the optimizer will handle this if we are not forcing
             return
         for group in self.params:
-            for param in group['params']:
-                if isinstance(param, torch.nn.Parameter):  # Ensure it's a proper parameter
+            for param in group["params"]:
+                if isinstance(
+                    param, torch.nn.Parameter
+                ):  # Ensure it's a proper parameter
                     param.requires_grad_(True)
 
     def setup_ema(self):
@@ -719,7 +827,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             # our params are in groups. We need them as a single iterable
             params = []
             for group in self.optimizer.param_groups:
-                for param in group['params']:
+                for param in group["params"]:
                     params.append(param)
             self.ema = ExponentialMovingAverage(
                 params,
@@ -739,11 +847,11 @@ class BaseSDTrainProcess(BaseTrainProcess):
     def hook_train_loop(self, batch):
         # return loss
         return 0.0
-    
+
     def hook_after_sd_init_before_load(self):
         pass
 
-    def get_latest_save_path(self, name=None, post=''):
+    def get_latest_save_path(self, name=None, post=""):
         if name == None:
             name = self.job.name
         # get latest saved step
@@ -753,7 +861,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
             patterns = [
                 f"{name}*{post}.safetensors",
                 f"{name}*{post}.pt",
-                f"{name}*{post}"
+                f"{name}*{post}",
             ]
             # Search for both files and directories
             paths = []
@@ -764,14 +872,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
             if paths:
                 paths = [p for p in paths if os.path.exists(p)]
                 # remove false positives
-                if '_LoRA' not in name:
-                    paths = [p for p in paths if '_LoRA' not in p]
-                if '_refiner' not in name:
-                    paths = [p for p in paths if '_refiner' not in p]
-                if '_t2i' not in name:
-                    paths = [p for p in paths if '_t2i' not in p]
-                if '_cn' not in name:
-                    paths = [p for p in paths if '_cn' not in p]
+                if "_LoRA" not in name:
+                    paths = [p for p in paths if "_LoRA" not in p]
+                if "_refiner" not in name:
+                    paths = [p for p in paths if "_refiner" not in p]
+                if "_t2i" not in name:
+                    paths = [p for p in paths if "_t2i" not in p]
+                if "_cn" not in name:
+                    paths = [p for p in paths if "_cn" not in p]
 
                 if len(paths) > 0:
                     latest_path = max(paths, key=os.path.getctime)
@@ -784,18 +892,23 @@ class BaseSDTrainProcess(BaseTrainProcess):
         meta = None
         # if path is folder, then it is diffusers
         if os.path.isdir(path):
-            meta_path = os.path.join(path, 'aitk_meta.yaml')
+            meta_path = os.path.join(path, "aitk_meta.yaml")
             # load it
             if os.path.exists(meta_path):
-                with open(meta_path, 'r') as f:
+                with open(meta_path, "r") as f:
                     meta = yaml.load(f, Loader=yaml.FullLoader)
         else:
             meta = load_metadata_from_safetensors(path)
         # if 'training_info' in Orderdict keys
-        if meta is not None and 'training_info' in meta and 'step' in meta['training_info'] and self.train_config.start_step is None:
-            self.step_num = meta['training_info']['step']
-            if 'epoch' in meta['training_info']:
-                self.epoch_num = meta['training_info']['epoch']
+        if (
+            meta is not None
+            and "training_info" in meta
+            and "step" in meta["training_info"]
+            and self.train_config.start_step is None
+        ):
+            self.step_num = meta["training_info"]["step"]
+            if "epoch" in meta["training_info"]:
+                self.epoch_num = meta["training_info"]["epoch"]
             self.start_step = self.step_num
             print_acc(f"Found step {self.step_num} in metadata, starting from there")
 
@@ -811,13 +924,32 @@ class BaseSDTrainProcess(BaseTrainProcess):
     def apply_snr(self, seperated_loss, timesteps):
         if self.train_config.learnable_snr_gos:
             # add snr_gamma
-            seperated_loss = apply_learnable_snr_gos(seperated_loss, timesteps, self.snr_gos)
-        elif self.train_config.snr_gamma is not None and self.train_config.snr_gamma > 0.000001:
+            seperated_loss = apply_learnable_snr_gos(
+                seperated_loss, timesteps, self.snr_gos
+            )
+        elif (
+            self.train_config.snr_gamma is not None
+            and self.train_config.snr_gamma > 0.000001
+        ):
             # add snr_gamma
-            seperated_loss = apply_snr_weight(seperated_loss, timesteps, self.sd.noise_scheduler, self.train_config.snr_gamma, fixed=True)
-        elif self.train_config.min_snr_gamma is not None and self.train_config.min_snr_gamma > 0.000001:
+            seperated_loss = apply_snr_weight(
+                seperated_loss,
+                timesteps,
+                self.sd.noise_scheduler,
+                self.train_config.snr_gamma,
+                fixed=True,
+            )
+        elif (
+            self.train_config.min_snr_gamma is not None
+            and self.train_config.min_snr_gamma > 0.000001
+        ):
             # add min_snr_gamma
-            seperated_loss = apply_snr_weight(seperated_loss, timesteps, self.sd.noise_scheduler, self.train_config.min_snr_gamma)
+            seperated_loss = apply_snr_weight(
+                seperated_loss,
+                timesteps,
+                self.sd.noise_scheduler,
+                self.train_config.min_snr_gamma,
+            )
 
         return seperated_loss
 
@@ -831,12 +963,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
             meta = load_metadata_from_safetensors(latest_save_path)
             # if 'training_info' in Orderdict keys
-            if 'training_info' in meta and 'step' in meta['training_info']:
-                self.step_num = meta['training_info']['step']
-                if 'epoch' in meta['training_info']:
-                    self.epoch_num = meta['training_info']['epoch']
+            if "training_info" in meta and "step" in meta["training_info"]:
+                self.step_num = meta["training_info"]["step"]
+                if "epoch" in meta["training_info"]:
+                    self.epoch_num = meta["training_info"]["epoch"]
                 self.start_step = self.step_num
-                print_acc(f"Found step {self.step_num} in metadata, starting from there")
+                print_acc(
+                    f"Found step {self.step_num} in metadata, starting from there"
+                )
 
     # def get_sigmas(self, timesteps, n_dim=4, dtype=torch.float32):
     #     self.sd.noise_scheduler.set_timesteps(1000, device=self.device_torch)
@@ -867,13 +1001,16 @@ class BaseSDTrainProcess(BaseTrainProcess):
         while len(sigma.shape) < n_dim:
             sigma = sigma.unsqueeze(-1)
         return sigma
-    
+
     def get_optimal_noise(self, latents, dtype=torch.float32):
         batch_num = latents.shape[0]
         chunks = torch.chunk(latents, batch_num, dim=0)
         noise_chunks = []
         for chunk in chunks:
-            noise_samples = [torch.randn_like(chunk, device=chunk.device, dtype=dtype) for _ in range(self.train_config.optimal_noise_pairing_samples)]
+            noise_samples = [
+                torch.randn_like(chunk, device=chunk.device, dtype=dtype)
+                for _ in range(self.train_config.optimal_noise_pairing_samples)
+            ]
             # find the one most similar to the chunk
             lowest_loss = 999999999999
             best_noise = None
@@ -885,8 +1022,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
             noise_chunks.append(best_noise)
         noise = torch.cat(noise_chunks, dim=0)
         return noise
-    
-    def get_consistent_noise(self, latents, batch: 'DataLoaderBatchDTO', dtype=torch.float32):
+
+    def get_consistent_noise(
+        self, latents, batch: "DataLoaderBatchDTO", dtype=torch.float32
+    ):
         batch_num = latents.shape[0]
         chunks = torch.chunk(latents, batch_num, dim=0)
         noise_chunks = []
@@ -896,23 +1035,24 @@ class BaseSDTrainProcess(BaseTrainProcess):
             img_path = file_item.path
             # add augmentors
             if file_item.flip_x:
-                img_path += '_fx'
+                img_path += "_fx"
             if file_item.flip_y:
-                img_path += '_fy'
-            seed = int(hashlib.md5(img_path.encode()).hexdigest(), 16) & 0xffffffff
+                img_path += "_fy"
+            seed = int(hashlib.md5(img_path.encode()).hexdigest(), 16) & 0xFFFFFFFF
             generator = torch.Generator("cpu").manual_seed(seed)
-            noise_chunk = torch.randn(chunk.shape, generator=generator).to(chunk.device, dtype=dtype)
+            noise_chunk = torch.randn(chunk.shape, generator=generator).to(
+                chunk.device, dtype=dtype
+            )
             noise_chunks.append(noise_chunk)
         noise = torch.cat(noise_chunks, dim=0).to(dtype=dtype)
         return noise
-            
 
     def get_noise(
-        self, 
-        latents, 
-        batch_size, 
-        dtype=torch.float32, 
-        batch: 'DataLoaderBatchDTO' = None,
+        self,
+        latents,
+        batch_size,
+        dtype=torch.float32,
+        batch: "DataLoaderBatchDTO" = None,
         timestep=None,
     ):
         if self.train_config.optimal_noise_pairing_samples > 1:
@@ -922,8 +1062,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 raise ValueError("Batch must be provided for consistent noise")
             noise = self.get_consistent_noise(latents, batch, dtype=dtype)
         else:
-            if hasattr(self.sd, 'get_latent_noise_from_latents'):
-                noise = self.sd.get_latent_noise_from_latents(latents).to(self.device_torch, dtype=dtype)
+            if hasattr(self.sd, "get_latent_noise_from_latents"):
+                noise = self.sd.get_latent_noise_from_latents(latents).to(
+                    self.device_torch, dtype=dtype
+                )
             else:
                 # get noise
                 noise = self.sd.get_latent_noise(
@@ -944,17 +1086,15 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
         #     # add to noise
         #     noise += noise_shift
-        
+
         if self.train_config.blended_blur_noise:
-            noise = get_blended_blur_noise(
-                latents, noise, timestep
-            )
+            noise = get_blended_blur_noise(latents, noise, timestep)
 
         return noise
 
-    def process_general_training_batch(self, batch: 'DataLoaderBatchDTO'):
+    def process_general_training_batch(self, batch: "DataLoaderBatchDTO"):
         with torch.no_grad():
-            with self.timer('prepare_prompt'):
+            with self.timer("prepare_prompt"):
                 prompts = batch.get_caption_list()
                 is_reg_list = batch.get_is_reg_list()
 
@@ -968,7 +1108,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     # double batch and add short captions to the end
                     prompts = prompts + batch.get_caption_short_list()
                     is_reg_list = is_reg_list + is_reg_list
-                if self.model_config.refiner_name_or_path is not None and self.train_config.train_unet:
+                if (
+                    self.model_config.refiner_name_or_path is not None
+                    and self.train_config.train_unet
+                ):
                     prompts = prompts + prompts
                     is_reg_list = is_reg_list + is_reg_list
 
@@ -1002,15 +1145,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     if not is_reg and self.train_config.prompt_saturation_chance > 0.0:
                         # do random prompt saturation by expanding the prompt to hit at least 77 tokens
                         if random.random() < self.train_config.prompt_saturation_chance:
-                            est_num_tokens = len(prompt.split(' '))
+                            est_num_tokens = len(prompt.split(" "))
                             if est_num_tokens < 77:
                                 num_repeats = int(77 / est_num_tokens) + 1
-                                prompt = ', '.join([prompt] * num_repeats)
-
+                                prompt = ", ".join([prompt] * num_repeats)
 
                     conditioned_prompts.append(prompt)
 
-            with self.timer('prepare_latents'):
+            with self.timer("prepare_latents"):
                 dtype = get_torch_dtype(self.train_config.dtype)
                 imgs = None
                 is_reg = any(batch.get_is_reg_list())
@@ -1039,8 +1181,12 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         imgs_channel_mean = imgs.mean(dim=(2, 3), keepdim=True)
                         imgs_channel_std = imgs.std(dim=(2, 3), keepdim=True)
                         imgs = (imgs - imgs_channel_mean) / imgs_channel_std
-                        target_mean = torch.tensor(target_mean_list, device=self.device_torch, dtype=dtype)
-                        target_std = torch.tensor(target_std_list, device=self.device_torch, dtype=dtype)
+                        target_mean = torch.tensor(
+                            target_mean_list, device=self.device_torch, dtype=dtype
+                        )
+                        target_std = torch.tensor(
+                            target_std_list, device=self.device_torch, dtype=dtype
+                        )
                         # expand them to match dim
                         target_mean = target_mean.unsqueeze(0).unsqueeze(2).unsqueeze(3)
                         target_std = target_std.unsqueeze(0).unsqueeze(2).unsqueeze(3)
@@ -1064,8 +1210,12 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     latents_channel_mean = latents.mean(dim=(2, 3), keepdim=True)
                     latents_channel_std = latents.std(dim=(2, 3), keepdim=True)
                     latents = (latents - latents_channel_mean) / latents_channel_std
-                    target_mean = torch.tensor(target_mean_list, device=self.device_torch, dtype=dtype)
-                    target_std = torch.tensor(target_std_list, device=self.device_torch, dtype=dtype)
+                    target_mean = torch.tensor(
+                        target_mean_list, device=self.device_torch, dtype=dtype
+                    )
+                    target_std = torch.tensor(
+                        target_std_list, device=self.device_torch, dtype=dtype
+                    )
                     # expand them to match dim
                     target_mean = target_mean.unsqueeze(0).unsqueeze(2).unsqueeze(3)
                     target_std = target_std.unsqueeze(0).unsqueeze(2).unsqueeze(3)
@@ -1075,17 +1225,25 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                     # show_latents(latents, self.sd.vae, 'latents')
 
-
-                if batch.unconditional_tensor is not None and batch.unconditional_latents is None:
+                if (
+                    batch.unconditional_tensor is not None
+                    and batch.unconditional_latents is None
+                ):
                     unconditional_imgs = batch.unconditional_tensor
-                    unconditional_imgs = unconditional_imgs.to(self.device_torch, dtype=dtype)
+                    unconditional_imgs = unconditional_imgs.to(
+                        self.device_torch, dtype=dtype
+                    )
                     unconditional_latents = self.sd.encode_images(unconditional_imgs)
-                    batch.unconditional_latents = unconditional_latents * self.train_config.latent_multiplier
+                    batch.unconditional_latents = (
+                        unconditional_latents * self.train_config.latent_multiplier
+                    )
 
                 unaugmented_latents = None
-                if self.train_config.loss_target == 'differential_noise':
+                if self.train_config.loss_target == "differential_noise":
                     # we determine noise from the differential of the latents
-                    unaugmented_latents = self.sd.encode_images(batch.unaugmented_tensor)
+                    unaugmented_latents = self.sd.encode_images(
+                        batch.unaugmented_tensor
+                    )
 
             batch_size = len(batch.file_items)
             min_noise_steps = self.train_config.min_denoising_steps
@@ -1093,48 +1251,59 @@ class BaseSDTrainProcess(BaseTrainProcess):
             if self.model_config.refiner_name_or_path is not None:
                 # if we are not training the unet, then we are only doing refiner and do not need to double up
                 if self.train_config.train_unet:
-                    max_noise_steps = round(self.train_config.max_denoising_steps * self.model_config.refiner_start_at)
+                    max_noise_steps = round(
+                        self.train_config.max_denoising_steps
+                        * self.model_config.refiner_start_at
+                    )
                     do_double = True
                 else:
-                    min_noise_steps = round(self.train_config.max_denoising_steps * self.model_config.refiner_start_at)
+                    min_noise_steps = round(
+                        self.train_config.max_denoising_steps
+                        * self.model_config.refiner_start_at
+                    )
                     do_double = False
 
-            with self.timer('prepare_noise'):
+            with self.timer("prepare_noise"):
                 num_train_timesteps = self.train_config.num_train_timesteps
 
-                if self.train_config.noise_scheduler in ['custom_lcm']:
+                if self.train_config.noise_scheduler in ["custom_lcm"]:
                     # we store this value on our custom one
                     self.sd.noise_scheduler.set_timesteps(
-                        self.sd.noise_scheduler.train_timesteps, device=self.device_torch
+                        self.sd.noise_scheduler.train_timesteps,
+                        device=self.device_torch,
                     )
-                elif self.train_config.noise_scheduler in ['lcm']:
+                elif self.train_config.noise_scheduler in ["lcm"]:
                     self.sd.noise_scheduler.set_timesteps(
-                        num_train_timesteps, device=self.device_torch, original_inference_steps=num_train_timesteps
+                        num_train_timesteps,
+                        device=self.device_torch,
+                        original_inference_steps=num_train_timesteps,
                     )
-                elif self.train_config.noise_scheduler == 'flowmatch':
-                    linear_timesteps = any([
-                        self.train_config.linear_timesteps,
-                        self.train_config.linear_timesteps2,
-                        self.train_config.timestep_type == 'linear',
-                        self.train_config.timestep_type == 'one_step',
-                    ])
-                    
-                    timestep_type = 'linear' if linear_timesteps else None
+                elif self.train_config.noise_scheduler == "flowmatch":
+                    linear_timesteps = any(
+                        [
+                            self.train_config.linear_timesteps,
+                            self.train_config.linear_timesteps2,
+                            self.train_config.timestep_type == "linear",
+                            self.train_config.timestep_type == "one_step",
+                        ]
+                    )
+
+                    timestep_type = "linear" if linear_timesteps else None
                     if timestep_type is None:
                         timestep_type = self.train_config.timestep_type
-                    
-                    if self.train_config.timestep_type == 'next_sample':
+
+                    if self.train_config.timestep_type == "next_sample":
                         # simulate a sample
                         num_train_timesteps = self.train_config.next_sample_timesteps
-                        timestep_type = 'shift'
-                    
+                        timestep_type = "shift"
+
                     patch_size = 1
-                    if self.sd.is_flux or 'flex' in self.sd.arch:
+                    if self.sd.is_flux or "flex" in self.sd.arch:
                         # flux is a patch size of 1, but latents are divided by 2, so we need to double it
                         patch_size = 2
-                    elif hasattr(self.sd.unet.config, 'patch_size'):
+                    elif hasattr(self.sd.unet.config, "patch_size"):
                         patch_size = self.sd.unet.config.patch_size
-                    
+
                     self.sd.noise_scheduler.set_train_timesteps(
                         num_train_timesteps,
                         device=self.device_torch,
@@ -1152,17 +1321,19 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     content_or_style = self.train_config.content_or_style_reg
 
                 # if self.train_config.timestep_sampling == 'style' or self.train_config.timestep_sampling == 'content':
-                if self.train_config.timestep_type == 'next_sample':
+                if self.train_config.timestep_type == "next_sample":
                     timestep_indices = torch.randint(
-                            0,
-                            num_train_timesteps - 2, # -1 for 0 idx, -1 so we can step
-                            (batch_size,),
-                            device=self.device_torch
-                        )
+                        0,
+                        num_train_timesteps - 2,  # -1 for 0 idx, -1 so we can step
+                        (batch_size,),
+                        device=self.device_torch,
+                    )
                     timestep_indices = timestep_indices.long()
-                elif self.train_config.timestep_type == 'one_step':
-                    timestep_indices = torch.zeros((batch_size,), device=self.device_torch, dtype=torch.long)
-                elif content_or_style in ['style', 'content']:
+                elif self.train_config.timestep_type == "one_step":
+                    timestep_indices = torch.zeros(
+                        (batch_size,), device=self.device_torch, dtype=torch.long
+                    )
+                elif content_or_style in ["style", "content"]:
                     # this is from diffusers training code
                     # Cubic sampling for favoring later or earlier timesteps
                     # For more details about why cubic sampling is used for content / structure,
@@ -1173,44 +1344,55 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                     orig_timesteps = torch.rand((batch_size,), device=latents.device)
 
-                    if content_or_style == 'content':
-                        timestep_indices = orig_timesteps ** 3 * self.train_config.num_train_timesteps
-                    elif content_or_style == 'style':
-                        timestep_indices = (1 - orig_timesteps ** 3) * self.train_config.num_train_timesteps
+                    if content_or_style == "content":
+                        timestep_indices = (
+                            orig_timesteps**3 * self.train_config.num_train_timesteps
+                        )
+                    elif content_or_style == "style":
+                        timestep_indices = (
+                            1 - orig_timesteps**3
+                        ) * self.train_config.num_train_timesteps
 
                     timestep_indices = value_map(
                         timestep_indices,
                         0,
                         self.train_config.num_train_timesteps - 1,
                         min_noise_steps,
-                        max_noise_steps - 1
+                        max_noise_steps - 1,
                     )
                     timestep_indices = timestep_indices.long().clamp(
-                        min_noise_steps + 1,
-                        max_noise_steps - 1
+                        min_noise_steps + 1, max_noise_steps - 1
                     )
-                    
-                elif content_or_style == 'balanced':
+
+                elif content_or_style == "balanced":
                     if min_noise_steps == max_noise_steps:
-                        timestep_indices = torch.ones((batch_size,), device=self.device_torch) * min_noise_steps
+                        timestep_indices = (
+                            torch.ones((batch_size,), device=self.device_torch)
+                            * min_noise_steps
+                        )
                     else:
                         # todo, some schedulers use indices, otheres use timesteps. Not sure what to do here
                         timestep_indices = torch.randint(
                             min_noise_steps + 1,
                             max_noise_steps - 1,
                             (batch_size,),
-                            device=self.device_torch
+                            device=self.device_torch,
                         )
                     timestep_indices = timestep_indices.long()
                 else:
                     raise ValueError(f"Unknown content_or_style {content_or_style}")
 
                 # convert the timestep_indices to a timestep
-                timesteps = [self.sd.noise_scheduler.timesteps[x.item()] for x in timestep_indices]
+                timesteps = [
+                    self.sd.noise_scheduler.timesteps[x.item()]
+                    for x in timestep_indices
+                ]
                 timesteps = torch.stack(timesteps, dim=0)
 
                 # get noise
-                noise = self.get_noise(latents, batch_size, dtype=dtype, batch=batch, timestep=timesteps)
+                noise = self.get_noise(
+                    latents, batch_size, dtype=dtype, batch=batch, timestep=timesteps
+                )
 
                 # add dynamic noise offset. Dynamic noise is offsetting the noise to the same channelwise mean as the latents
                 # this will negate any noise offsets
@@ -1219,7 +1401,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     # subtract channel mean to that we compensate for the mean of the latents on the noise offset per channel
                     noise = noise + latents_channel_mean
 
-                if self.train_config.loss_target == 'differential_noise':
+                if self.train_config.loss_target == "differential_noise":
                     differential = latents - unaugmented_latents
                     # add noise to differential
                     # noise = noise + differential
@@ -1228,30 +1410,29 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     latents = unaugmented_latents
 
                 noise_multiplier = self.train_config.noise_multiplier
-                
+
                 s = (noise.shape[0], noise.shape[1], 1, 1)
                 if len(noise.shape) == 5:
                     # if we have a 5d tensor, then we need to do it on a per batch item, per channel basis, per frame
                     s = (noise.shape[0], noise.shape[1], noise.shape[2], 1, 1)
-                
+
                 if self.train_config.random_noise_multiplier > 0.0:
-                    
+
                     # do it on a per batch item, per channel basis
-                    noise_multiplier = 1 + torch.randn(
-                        s,
-                        device=noise.device,
-                        dtype=noise.dtype
-                    ) * self.train_config.random_noise_multiplier
+                    noise_multiplier = (
+                        1
+                        + torch.randn(s, device=noise.device, dtype=noise.dtype)
+                        * self.train_config.random_noise_multiplier
+                    )
 
                 noise = noise * noise_multiplier
-                
+
                 if self.train_config.random_noise_shift > 0.0:
                     # get random noise -1 to 1
-                    noise_shift = torch.randn(
-                        s,  
-                        device=noise.device,
-                        dtype=noise.dtype
-                    ) * self.train_config.random_noise_shift
+                    noise_shift = (
+                        torch.randn(s, device=noise.device, dtype=noise.dtype)
+                        * self.train_config.random_noise_shift
+                    )
                     # add to noise
                     noise += noise_shift
 
@@ -1271,8 +1452,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 # latents = mean_zero_latents / mean_zero_latents.std()
 
                 if batch.unconditional_latents is not None:
-                    batch.unconditional_latents = batch.unconditional_latents * self.train_config.latent_multiplier
-
+                    batch.unconditional_latents = (
+                        batch.unconditional_latents
+                        * self.train_config.latent_multiplier
+                    )
 
                 noisy_latents = self.sd.add_noise(latents, noise, timesteps)
 
@@ -1281,8 +1464,13 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 # noise = noisy_latents - latents
 
                 # https://github.com/huggingface/diffusers/blob/324d18fba23f6c9d7475b0ff7c777685f7128d40/examples/t2i_adapter/train_t2i_adapter_sdxl.py#L1170C17-L1171C77
-                if self.train_config.loss_target == 'source' or self.train_config.loss_target == 'unaugmented':
-                    sigmas = self.get_sigmas(timesteps, len(noisy_latents.shape), noisy_latents.dtype)
+                if (
+                    self.train_config.loss_target == "source"
+                    or self.train_config.loss_target == "unaugmented"
+                ):
+                    sigmas = self.get_sigmas(
+                        timesteps, len(noisy_latents.shape), noisy_latents.dtype
+                    )
                     # add it to the batch
                     batch.sigmas = sigmas
                     # todo is this for sdxl? find out where this came from originally
@@ -1300,14 +1488,18 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         max_noise_steps,
                         self.train_config.max_denoising_steps,
                         (batch_size,),
-                        device=self.device_torch
+                        device=self.device_torch,
                     )
                     refiner_timesteps = refiner_timesteps.long()
                     # add our new timesteps on to end
                     timesteps = torch.cat([timesteps, refiner_timesteps], dim=0)
 
-                    refiner_noisy_latents = self.sd.noise_scheduler.add_noise(latents, noise, refiner_timesteps)
-                    noisy_latents = torch.cat([noisy_latents, refiner_noisy_latents], dim=0)
+                    refiner_noisy_latents = self.sd.noise_scheduler.add_noise(
+                        latents, noise, refiner_timesteps
+                    )
+                    noisy_latents = torch.cat(
+                        [noisy_latents, refiner_noisy_latents], dim=0
+                    )
 
                 else:
                     # just double it
@@ -1335,25 +1527,25 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
     def setup_adapter(self):
         # t2i adapter
-        is_t2i = self.adapter_config.type == 't2i'
-        is_control_net = self.adapter_config.type == 'control_net'
-        if self.adapter_config.type == 't2i':
-            suffix = 't2i'
-        elif self.adapter_config.type == 'control_net':
-            suffix = 'cn'
-        elif self.adapter_config.type == 'clip':
-            suffix = 'clip'
-        elif self.adapter_config.type == 'reference':
-            suffix = 'ref'
-        elif self.adapter_config.type.startswith('ip'):
-            suffix = 'ip'
+        is_t2i = self.adapter_config.type == "t2i"
+        is_control_net = self.adapter_config.type == "control_net"
+        if self.adapter_config.type == "t2i":
+            suffix = "t2i"
+        elif self.adapter_config.type == "control_net":
+            suffix = "cn"
+        elif self.adapter_config.type == "clip":
+            suffix = "clip"
+        elif self.adapter_config.type == "reference":
+            suffix = "ref"
+        elif self.adapter_config.type.startswith("ip"):
+            suffix = "ip"
         else:
-            suffix = 'adapter'
+            suffix = "adapter"
         adapter_name = self.name
         if self.network_config is not None:
             adapter_name = f"{adapter_name}_{suffix}"
         latest_save_path = self.get_latest_save_path(adapter_name)
-        
+
         if latest_save_path is not None and not self.adapter_config.train:
             # the save path is for something else since we are not training
             latest_save_path = self.adapter_config.name_or_path
@@ -1362,7 +1554,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
         if is_t2i:
             # if we do not have a last save path and we have a name_or_path,
             # load from that
-            if latest_save_path is None and self.adapter_config.name_or_path is not None:
+            if (
+                latest_save_path is None
+                and self.adapter_config.name_or_path is not None
+            ):
                 self.adapter = T2IAdapter.from_pretrained(
                     self.adapter_config.name_or_path,
                     torch_dtype=get_torch_dtype(self.train_config.dtype),
@@ -1379,7 +1574,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 )
         elif is_control_net:
             if self.adapter_config.name_or_path is None:
-                raise ValueError("ControlNet requires a name_or_path to load from currently")
+                raise ValueError(
+                    "ControlNet requires a name_or_path to load from currently"
+                )
             load_from_path = self.adapter_config.name_or_path
             if latest_save_path is not None:
                 load_from_path = latest_save_path
@@ -1387,17 +1584,17 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 load_from_path,
                 torch_dtype=get_torch_dtype(self.train_config.dtype),
             )
-        elif self.adapter_config.type == 'clip':
+        elif self.adapter_config.type == "clip":
             self.adapter = ClipVisionAdapter(
                 sd=self.sd,
                 adapter_config=self.adapter_config,
             )
-        elif self.adapter_config.type == 'reference':
+        elif self.adapter_config.type == "reference":
             self.adapter = ReferenceAdapter(
                 sd=self.sd,
                 adapter_config=self.adapter_config,
             )
-        elif self.adapter_config.type.startswith('ip'):
+        elif self.adapter_config.type.startswith("ip"):
             self.adapter = IPAdapter(
                 sd=self.sd,
                 adapter_config=self.adapter_config,
@@ -1416,26 +1613,22 @@ class BaseSDTrainProcess(BaseTrainProcess):
             print_acc(f"Loading adapter from {latest_save_path}")
             if is_t2i:
                 loaded_state_dict = load_t2i_model(
-                    latest_save_path,
-                    self.device,
-                    dtype=dtype
+                    latest_save_path, self.device, dtype=dtype
                 )
                 self.adapter.load_state_dict(loaded_state_dict)
-            elif self.adapter_config.type.startswith('ip'):
+            elif self.adapter_config.type.startswith("ip"):
                 # ip adapter
                 loaded_state_dict = load_ip_adapter_model(
                     latest_save_path,
                     self.device,
                     dtype=dtype,
-                    direct_load=self.adapter_config.train_only_image_encoder
+                    direct_load=self.adapter_config.train_only_image_encoder,
                 )
                 self.adapter.load_state_dict(loaded_state_dict)
             else:
                 # custom adapter
                 loaded_state_dict = load_custom_adapter_model(
-                    latest_save_path,
-                    self.device,
-                    dtype=dtype
+                    latest_save_path, self.device, dtype=dtype
                 )
                 self.adapter.load_state_dict(loaded_state_dict)
         if latest_save_path is not None and self.adapter_config.train:
@@ -1465,27 +1658,35 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
         ModelClass = get_model_class(self.model_config)
         # if the model class has get_train_scheduler static method
-        if hasattr(ModelClass, 'get_train_scheduler'):
+        if hasattr(ModelClass, "get_train_scheduler"):
             sampler = ModelClass.get_train_scheduler()
         else:
             # get the noise scheduler
-            arch = 'sd'
+            arch = "sd"
             if self.model_config.is_pixart:
-                arch = 'pixart'
+                arch = "pixart"
             if self.model_config.is_flux:
-                arch = 'flux'
+                arch = "flux"
             if self.model_config.is_lumina2:
-                arch = 'lumina2'
+                arch = "lumina2"
             sampler = get_sampler(
                 self.train_config.noise_scheduler,
                 {
-                    "prediction_type": "v_prediction" if self.model_config.is_v_pred else "epsilon",
+                    "prediction_type": (
+                        "v_prediction" if self.model_config.is_v_pred else "epsilon"
+                    ),
                 },
                 arch=arch,
             )
 
-        if self.train_config.train_refiner and self.model_config.refiner_name_or_path is not None and self.network_config is None:
-            previous_refiner_save = self.get_latest_save_path(self.job.name + '_refiner')
+        if (
+            self.train_config.train_refiner
+            and self.model_config.refiner_name_or_path is not None
+            and self.network_config is None
+        ):
+            previous_refiner_save = self.get_latest_save_path(
+                self.job.name + "_refiner"
+            )
             if previous_refiner_save is not None:
                 model_config_to_load.refiner_name_or_path = previous_refiner_save
                 self.load_training_state_from_metadata(previous_refiner_save)
@@ -1499,11 +1700,11 @@ class BaseSDTrainProcess(BaseTrainProcess):
             custom_pipeline=self.custom_pipeline,
             noise_scheduler=sampler,
         )
-        
+
         self.hook_after_sd_init_before_load()
         # run base sd process run
         self.sd.load_model()
-        
+
         self.sd.add_after_sample_image_hook(self.sample_step_hook)
 
         dtype = get_torch_dtype(self.train_config.dtype)
@@ -1521,13 +1722,13 @@ class BaseSDTrainProcess(BaseTrainProcess):
             if isinstance(text_encoder, list):
                 for te in text_encoder:
                     # if it has it
-                    if hasattr(te, 'enable_xformers_memory_efficient_attention'):
+                    if hasattr(te, "enable_xformers_memory_efficient_attention"):
                         te.enable_xformers_memory_efficient_attention()
         if self.train_config.sdp:
             torch.backends.cuda.enable_math_sdp(True)
             torch.backends.cuda.enable_flash_sdp(True)
             torch.backends.cuda.enable_mem_efficient_sdp(True)
-        
+
         # # check if we have sage and is flux
         # if self.sd.is_flux:
         #     # try_to_activate_sage_attn()
@@ -1542,26 +1743,26 @@ class BaseSDTrainProcess(BaseTrainProcess):
         #         for block in model.single_transformer_blocks:
         #             processor = FluxSageAttnProcessor2_0()
         #             block.attn.set_processor(processor)
-                    
+
         #     except ImportError:
         #         print_acc("sage attention is not installed. Using SDP instead")
 
         if self.train_config.gradient_checkpointing:
             # if has method enable_gradient_checkpointing
-            if hasattr(unet, 'enable_gradient_checkpointing'):
+            if hasattr(unet, "enable_gradient_checkpointing"):
                 unet.enable_gradient_checkpointing()
-            elif hasattr(unet, 'gradient_checkpointing'):
+            elif hasattr(unet, "gradient_checkpointing"):
                 unet.gradient_checkpointing = True
             else:
                 print("Gradient checkpointing not supported on this model")
             if isinstance(text_encoder, list):
                 for te in text_encoder:
-                    if hasattr(te, 'enable_gradient_checkpointing'):
+                    if hasattr(te, "enable_gradient_checkpointing"):
                         te.enable_gradient_checkpointing()
                     if hasattr(te, "gradient_checkpointing_enable"):
                         te.gradient_checkpointing_enable()
             else:
-                if hasattr(text_encoder, 'enable_gradient_checkpointing'):
+                if hasattr(text_encoder, "enable_gradient_checkpointing"):
                     text_encoder.enable_gradient_checkpointing()
                 if hasattr(text_encoder, "gradient_checkpointing_enable"):
                     text_encoder.gradient_checkpointing_enable()
@@ -1585,7 +1786,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
         unet.to(self.device_torch, dtype=dtype)
         unet.requires_grad_(False)
         unet.eval()
-        vae = vae.to(torch.device('cpu'), dtype=dtype)
+        vae = vae.to(torch.device("cpu"), dtype=dtype)
         vae.requires_grad_(False)
         vae.eval()
         if self.train_config.learnable_snr_gos:
@@ -1593,18 +1794,28 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 self.sd.noise_scheduler, device=self.device_torch
             )
             # check to see if previous settings exist
-            path_to_load = os.path.join(self.save_root, 'learnable_snr.json')
+            path_to_load = os.path.join(self.save_root, "learnable_snr.json")
             if os.path.exists(path_to_load):
-                with open(path_to_load, 'r') as f:
+                with open(path_to_load, "r") as f:
                     json_data = json.load(f)
-                    if 'offset' in json_data:
+                    if "offset" in json_data:
                         # legacy
-                        self.snr_gos.offset_2.data = torch.tensor(json_data['offset'], device=self.device_torch)
+                        self.snr_gos.offset_2.data = torch.tensor(
+                            json_data["offset"], device=self.device_torch
+                        )
                     else:
-                        self.snr_gos.offset_1.data = torch.tensor(json_data['offset_1'], device=self.device_torch)
-                        self.snr_gos.offset_2.data = torch.tensor(json_data['offset_2'], device=self.device_torch)
-                    self.snr_gos.scale.data = torch.tensor(json_data['scale'], device=self.device_torch)
-                    self.snr_gos.gamma.data = torch.tensor(json_data['gamma'], device=self.device_torch)
+                        self.snr_gos.offset_1.data = torch.tensor(
+                            json_data["offset_1"], device=self.device_torch
+                        )
+                        self.snr_gos.offset_2.data = torch.tensor(
+                            json_data["offset_2"], device=self.device_torch
+                        )
+                    self.snr_gos.scale.data = torch.tensor(
+                        json_data["scale"], device=self.device_torch
+                    )
+                    self.snr_gos.gamma.data = torch.tensor(
+                        json_data["gamma"], device=self.device_torch
+                    )
 
         self.hook_after_model_load()
         flush()
@@ -1613,24 +1824,27 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 # TODO should we completely switch to LycorisSpecialNetwork?
                 network_kwargs = self.network_config.network_kwargs
                 is_lycoris = False
-                is_lorm = self.network_config.type.lower() == 'lorm'
+                is_lorm = self.network_config.type.lower() == "lorm"
                 # default to LoCON if there are any conv layers or if it is named
                 NetworkClass = LoRASpecialNetwork
-                if self.network_config.type.lower() == 'locon' or self.network_config.type.lower() == 'lycoris':
+                if (
+                    self.network_config.type.lower() == "locon"
+                    or self.network_config.type.lower() == "lycoris"
+                ):
                     NetworkClass = LycorisSpecialNetwork
                     is_lycoris = True
 
                 if is_lorm:
-                    network_kwargs['ignore_if_contains'] = lorm_ignore_if_contains
-                    network_kwargs['parameter_threshold'] = lorm_parameter_threshold
-                    network_kwargs['target_lin_modules'] = LORM_TARGET_REPLACE_MODULE
+                    network_kwargs["ignore_if_contains"] = lorm_ignore_if_contains
+                    network_kwargs["parameter_threshold"] = lorm_parameter_threshold
+                    network_kwargs["target_lin_modules"] = LORM_TARGET_REPLACE_MODULE
 
                 # if is_lycoris:
                 #     preset = PRESET['full']
                 # NetworkClass.apply_preset(preset)
-                
-                if hasattr(self.sd, 'target_lora_modules'):
-                    network_kwargs['target_lin_modules'] = self.sd.target_lora_modules
+
+                if hasattr(self.sd, "target_lora_modules"):
+                    network_kwargs["target_lin_modules"] = self.sd.target_lora_modules
 
                 self.network = NetworkClass(
                     text_encoder=text_encoder,
@@ -1661,9 +1875,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     transformer_only=self.network_config.transformer_only,
                     is_transformer=self.sd.is_transformer,
                     base_model=self.sd,
-                    **network_kwargs
+                    **network_kwargs,
                 )
-
 
                 # todo switch everything to proper mixed precision like this
                 self.network.force_to(self.device_torch, dtype=torch.float32)
@@ -1675,7 +1888,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     text_encoder,
                     unet,
                     self.train_config.train_text_encoder,
-                    self.train_config.train_unet
+                    self.train_config.train_unet,
                 )
 
                 # we cannot merge in if quantized
@@ -1689,7 +1902,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     self.sd.unet.to(self.sd.device, dtype=dtype)
                     original_unet_param_count = count_parameters(self.sd.unet)
                     self.network.setup_lorm()
-                    new_unet_param_count = original_unet_param_count - self.network.calculate_lorem_parameter_reduction()
+                    new_unet_param_count = (
+                        original_unet_param_count
+                        - self.network.calculate_lorem_parameter_reduction()
+                    )
 
                     print_lorm_extract_details(
                         start_num_params=original_unet_param_count,
@@ -1702,17 +1918,15 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                 # LyCORIS doesnt have default_lr
                 config = {
-                    'text_encoder_lr': self.train_config.lr,
-                    'unet_lr': self.train_config.lr,
+                    "text_encoder_lr": self.train_config.lr,
+                    "unet_lr": self.train_config.lr,
                 }
                 sig = inspect.signature(self.network.prepare_optimizer_params)
-                if 'default_lr' in sig.parameters:
-                    config['default_lr'] = self.train_config.lr
-                if 'learning_rate' in sig.parameters:
-                    config['learning_rate'] = self.train_config.lr
-                params_net = self.network.prepare_optimizer_params(
-                    **config
-                )
+                if "default_lr" in sig.parameters:
+                    config["default_lr"] = self.train_config.lr
+                if "learning_rate" in sig.parameters:
+                    config["learning_rate"] = self.train_config.lr
+                params_net = self.network.prepare_optimizer_params(**config)
 
                 params += params_net
 
@@ -1734,31 +1948,32 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
             if self.embed_config is not None:
                 # we are doing embedding training as well
-                self.embedding = Embedding(
-                    sd=self.sd,
-                    embed_config=self.embed_config
-                )
+                self.embedding = Embedding(sd=self.sd, embed_config=self.embed_config)
                 latest_save_path = self.get_latest_save_path(self.embed_config.trigger)
                 # load last saved weights
                 if latest_save_path is not None:
-                    self.embedding.load_embedding_from_file(latest_save_path, self.device_torch)
+                    self.embedding.load_embedding_from_file(
+                        latest_save_path, self.device_torch
+                    )
                     if self.embedding.step > 1:
                         self.step_num = self.embedding.step
                         self.start_step = self.step_num
 
                 # self.step_num = self.embedding.step
                 # self.start_step = self.step_num
-                params.append({
-                    'params': list(self.embedding.get_trainable_params()),
-                    'lr': self.train_config.embedding_lr
-                })
+                params.append(
+                    {
+                        "params": list(self.embedding.get_trainable_params()),
+                        "lr": self.train_config.embedding_lr,
+                    }
+                )
 
                 flush()
-            
+
             if self.decorator_config is not None:
                 self.decorator = Decorator(
                     num_tokens=self.decorator_config.num_tokens,
-                    token_size=4096 # t5xxl hidden size for flux
+                    token_size=4096,  # t5xxl hidden size for flux
                 )
                 latest_save_path = self.get_latest_save_path()
                 # load last saved weights
@@ -1766,12 +1981,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     state_dict = load_file(latest_save_path)
                     self.decorator.load_state_dict(state_dict)
                     self.load_training_state_from_metadata(latest_save_path)
-                    
-                params.append({
-                    'params': list(self.decorator.parameters()),
-                    'lr': self.train_config.lr
-                })
-                
+
+                params.append(
+                    {
+                        "params": list(self.decorator.parameters()),
+                        "lr": self.train_config.lr,
+                    }
+                )
+
                 # give it to the sd network
                 self.sd.decorator = self.decorator
                 self.decorator.to(self.device_torch, dtype=torch.float32)
@@ -1785,15 +2002,19 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                     if isinstance(self.adapter, IPAdapter):
                         # we have custom LR groups for IPAdapter
-                        adapter_param_groups = self.adapter.get_parameter_groups(self.train_config.adapter_lr)
+                        adapter_param_groups = self.adapter.get_parameter_groups(
+                            self.train_config.adapter_lr
+                        )
                         for group in adapter_param_groups:
                             params.append(group)
                     else:
                         # set trainable params
-                        params.append({
-                            'params': list(self.adapter.parameters()),
-                            'lr': self.train_config.adapter_lr
-                        })
+                        params.append(
+                            {
+                                "params": list(self.adapter.parameters()),
+                                "lr": self.train_config.adapter_lr,
+                            }
+                        )
 
                 if self.train_config.gradient_checkpointing:
                     self.adapter.enable_gradient_checkpointing()
@@ -1814,7 +2035,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     text_encoder_lr=self.train_config.lr,
                     unet_lr=self.train_config.lr,
                     default_lr=self.train_config.lr,
-                    refiner=self.train_config.train_refiner and self.sd.refiner_unet is not None,
+                    refiner=self.train_config.train_refiner
+                    and self.sd.refiner_unet is not None,
                     refiner_lr=self.train_config.refiner_lr,
                 )
             # we may be using it for prompt injections
@@ -1837,45 +2059,57 @@ class BaseSDTrainProcess(BaseTrainProcess):
             self.start_step = self.step_num
 
         optimizer_type = self.train_config.optimizer.lower()
-        
+
         # esure params require grad
         self.ensure_params_requires_grad(force=True)
-        optimizer = get_optimizer(self.params, optimizer_type, learning_rate=self.train_config.lr,
-                                  optimizer_params=self.train_config.optimizer_params)
+        optimizer = get_optimizer(
+            self.params,
+            optimizer_type,
+            learning_rate=self.train_config.lr,
+            optimizer_params=self.train_config.optimizer_params,
+        )
         self.optimizer = optimizer
-        
+
         # set it to do paramiter swapping
         if self.train_config.do_paramiter_swapping:
             # only works for adafactor, but it should have thrown an error prior to this otherwise
-            self.optimizer.enable_paramiter_swapping(self.train_config.paramiter_swapping_factor)
+            self.optimizer.enable_paramiter_swapping(
+                self.train_config.paramiter_swapping_factor
+            )
 
         # check if it exists
-        optimizer_state_filename = f'optimizer.pt'
-        optimizer_state_file_path = os.path.join(self.save_root, optimizer_state_filename)
+        optimizer_state_filename = f"optimizer.pt"
+        optimizer_state_file_path = os.path.join(
+            self.save_root, optimizer_state_filename
+        )
         if os.path.exists(optimizer_state_file_path):
             # try to load
             # previous param groups
             # previous_params = copy.deepcopy(optimizer.param_groups)
             previous_lrs = []
             for group in optimizer.param_groups:
-                previous_lrs.append(group['lr'])
+                previous_lrs.append(group["lr"])
 
             try:
                 print_acc(f"Loading optimizer state from {optimizer_state_file_path}")
-                optimizer_state_dict = torch.load(optimizer_state_file_path, weights_only=True)
+                optimizer_state_dict = torch.load(
+                    optimizer_state_file_path, weights_only=True
+                )
                 optimizer.load_state_dict(optimizer_state_dict)
                 del optimizer_state_dict
                 flush()
             except Exception as e:
-                print_acc(f"Failed to load optimizer state from {optimizer_state_file_path}")
+                print_acc(
+                    f"Failed to load optimizer state from {optimizer_state_file_path}"
+                )
                 print_acc(e)
 
             # update the optimizer LR from the params
             print_acc(f"Updating optimizer LR from params")
             if len(previous_lrs) > 0:
                 for i, group in enumerate(optimizer.param_groups):
-                    group['lr'] = previous_lrs[i]
-                    group['initial_lr'] = previous_lrs[i]
+                    group["lr"] = previous_lrs[i]
+                    group["initial_lr"] = previous_lrs[i]
 
             # Update the learning rates if they changed
             # optimizer.param_groups = previous_params
@@ -1883,13 +2117,11 @@ class BaseSDTrainProcess(BaseTrainProcess):
         lr_scheduler_params = self.train_config.lr_scheduler_params
 
         # make sure it had bare minimum
-        if 'max_iterations' not in lr_scheduler_params:
-            lr_scheduler_params['total_iters'] = self.train_config.steps
+        if "max_iterations" not in lr_scheduler_params:
+            lr_scheduler_params["total_iters"] = self.train_config.steps
 
         lr_scheduler = get_lr_scheduler(
-            self.train_config.lr_scheduler,
-            optimizer,
-            **lr_scheduler_params
+            self.train_config.lr_scheduler, optimizer, **lr_scheduler_params
         )
         self.lr_scheduler = lr_scheduler
 
@@ -1897,17 +2129,36 @@ class BaseSDTrainProcess(BaseTrainProcess):
         self.before_dataset_load()
         # load datasets if passed in the root process
         if self.datasets is not None:
-            self.data_loader = get_dataloader_from_datasets(self.datasets, self.train_config.batch_size, self.sd)
+            loaders = get_dataloader_from_datasets(
+                self.datasets,
+                self.train_config.batch_size,
+                self.sd,
+                self.validation_every,
+            )
+            self.data_loader = loaders[0]
+            if len(loaders) > 1:
+                self.data_loader_val = loaders[1]
         if self.datasets_reg is not None:
-            self.data_loader_reg = get_dataloader_from_datasets(self.datasets_reg, self.train_config.batch_size,
-                                                                self.sd)
+            loaders_reg = get_dataloader_from_datasets(
+                self.datasets_reg,
+                self.train_config.batch_size,
+                self.sd,
+                self.validation_every,
+            )
+            self.data_loader_reg = loaders_reg[0]
+            if len(loaders_reg) > 1:
+                self.data_loader_val_reg = loaders_reg[1]
 
         flush()
         self.last_save_step = self.step_num
         ### HOOK ###
         self.hook_before_train_loop()
 
-        if self.has_first_sample_requested and self.step_num <= 1 and not self.train_config.disable_sampling:
+        if (
+            self.has_first_sample_requested
+            and self.step_num <= 1
+            and not self.train_config.disable_sampling
+        ):
             print_acc("Generating first sample from first sample config")
             self.sample(0, is_first=True)
 
@@ -1917,7 +2168,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
         elif self.step_num <= 1 or self.train_config.force_first_sample:
             print_acc("Generating baseline samples before training")
             self.sample(self.step_num)
-        
+
         if self.accelerator.is_local_main_process:
             self.progress_bar = ToolkitProgressBar(
                 total=self.train_config.steps,
@@ -1959,11 +2210,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # make sure all params require grad
         self.ensure_params_requires_grad(force=True)
 
-
         ###################################################################
         # TRAIN LOOP
         ###################################################################
-
 
         start_step_num = self.step_num
         did_first_flush = False
@@ -1971,13 +2220,15 @@ class BaseSDTrainProcess(BaseTrainProcess):
         for step in range(start_step_num, self.train_config.steps):
             if self.train_config.do_paramiter_swapping:
                 self.optimizer.optimizer.swap_paramiters()
-            self.timer.start('train_loop')
+            self.timer.start("train_loop")
             if flush_next:
                 flush()
                 flush_next = False
             if self.train_config.do_random_cfg:
                 self.train_config.do_cfg = True
-                self.train_config.cfg_scale = value_map(random.random(), 0, 1, 1.0, self.train_config.max_cfg_scale)
+                self.train_config.cfg_scale = value_map(
+                    random.random(), 0, 1, 1.0, self.train_config.max_cfg_scale
+                )
             self.step_num = step
             # default to true so various things can turn it off
             self.is_grad_accumulation_step = True
@@ -1989,40 +2240,51 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 # if is even step and we have a reg dataset, use that
                 # todo improve this logic to send one of each through if we can buckets and batch size might be an issue
                 is_reg_step = False
-                is_save_step = self.save_config.save_every and self.step_num % self.save_config.save_every == 0
-                is_sample_step = self.sample_config.sample_every and self.step_num % self.sample_config.sample_every == 0
+                is_save_step = (
+                    self.save_config.save_every
+                    and self.step_num % self.save_config.save_every == 0
+                )
+                is_sample_step = (
+                    self.sample_config.sample_every
+                    and self.step_num % self.sample_config.sample_every == 0
+                )
                 if self.train_config.disable_sampling:
                     is_sample_step = False
 
                 batch_list = []
 
                 for b in range(self.train_config.gradient_accumulation):
-                    # keep track to alternate on an accumulation step for reg   
+                    # keep track to alternate on an accumulation step for reg
                     batch_step = step
                     # don't do a reg step on sample or save steps as we dont want to normalize on those
-                    if batch_step % 2 == 0 and dataloader_reg is not None and not is_save_step and not is_sample_step:
+                    if (
+                        batch_step % 2 == 0
+                        and dataloader_reg is not None
+                        and not is_save_step
+                        and not is_sample_step
+                    ):
                         try:
-                            with self.timer('get_batch:reg'):
+                            with self.timer("get_batch:reg"):
                                 batch = next(dataloader_iterator_reg)
                         except StopIteration:
-                            with self.timer('reset_batch:reg'):
+                            with self.timer("reset_batch:reg"):
                                 # hit the end of an epoch, reset
                                 if self.progress_bar is not None:
                                     self.progress_bar.pause()
                                 dataloader_iterator_reg = iter(dataloader_reg)
                                 trigger_dataloader_setup_epoch(dataloader_reg)
 
-                            with self.timer('get_batch:reg'):
+                            with self.timer("get_batch:reg"):
                                 batch = next(dataloader_iterator_reg)
                             if self.progress_bar is not None:
                                 self.progress_bar.unpause()
                         is_reg_step = True
                     elif dataloader is not None:
                         try:
-                            with self.timer('get_batch'):
+                            with self.timer("get_batch"):
                                 batch = next(dataloader_iterator)
                         except StopIteration:
-                            with self.timer('reset_batch'):
+                            with self.timer("reset_batch"):
                                 # hit the end of an epoch, reset
                                 if self.progress_bar is not None:
                                     self.progress_bar.pause()
@@ -2033,7 +2295,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                                     # if we are accumulating for an entire epoch, trigger a step
                                     self.is_grad_accumulation_step = False
                                     self.grad_accumulation_step = 0
-                            with self.timer('get_batch'):
+                            with self.timer("get_batch"):
                                 batch = next(dataloader_iterator)
                             if self.progress_bar is not None:
                                 self.progress_bar.unpause()
@@ -2063,14 +2325,14 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     loss_dict = self.hook_train_loop(batch_list)
                 except Exception as e:
                     traceback.print_exc()
-                    #print batch info
+                    # print batch info
                     print("Batch Items:")
                     for batch in batch_list:
                         for item in batch.file_items:
                             print(f" - {item.path}")
                     raise e
-                    
-            self.timer.stop('train_loop')
+
+            self.timer.stop("train_loop")
             if not did_first_flush:
                 flush()
                 did_first_flush = True
@@ -2082,18 +2344,18 @@ class BaseSDTrainProcess(BaseTrainProcess):
             with torch.no_grad():
                 # torch.cuda.empty_cache()
                 # if optimizer has get_lrs method, then use it
-                if hasattr(optimizer, 'get_avg_learning_rate'):
+                if hasattr(optimizer, "get_avg_learning_rate"):
                     learning_rate = optimizer.get_avg_learning_rate()
-                elif hasattr(optimizer, 'get_learning_rates'):
+                elif hasattr(optimizer, "get_learning_rates"):
                     learning_rate = optimizer.get_learning_rates()[0]
-                elif self.train_config.optimizer.lower().startswith('dadaptation') or \
-                        self.train_config.optimizer.lower().startswith('prodigy'):
+                elif self.train_config.optimizer.lower().startswith(
+                    "dadaptation"
+                ) or self.train_config.optimizer.lower().startswith("prodigy"):
                     learning_rate = (
-                            optimizer.param_groups[0]["d"] *
-                            optimizer.param_groups[0]["lr"]
+                        optimizer.param_groups[0]["d"] * optimizer.param_groups[0]["lr"]
                     )
                 else:
-                    learning_rate = optimizer.param_groups[0]['lr']
+                    learning_rate = optimizer.param_groups[0]["lr"]
 
                 prog_bar_string = f"lr: {learning_rate:.1e}"
                 for key, value in loss_dict.items():
@@ -2104,7 +2366,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
 
                 # if the batch is a DataLoaderBatchDTO, then we need to clean it up
                 if isinstance(batch, DataLoaderBatchDTO):
-                    with self.timer('batch_cleanup'):
+                    with self.timer("batch_cleanup"):
                         batch.cleanup()
 
                 # don't do on first step
@@ -2121,7 +2383,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         self.sample(self.step_num)
                         if self.train_config.unload_text_encoder:
                             # make sure the text encoder is unloaded
-                            self.sd.text_encoder_to('cpu')
+                            self.sd.text_encoder_to("cpu")
                         flush()
 
                         self.ensure_params_requires_grad()
@@ -2143,41 +2405,58 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         if self.progress_bar is not None:
                             self.progress_bar.unpause()
 
-                    if self.logging_config.log_every and self.step_num % self.logging_config.log_every == 0:
+                    if (
+                        self.logging_config.log_every
+                        and self.step_num % self.logging_config.log_every == 0
+                    ):
                         if self.progress_bar is not None:
                             self.progress_bar.pause()
-                        with self.timer('log_to_tensorboard'):
+                        with self.timer("log_to_tensorboard"):
                             # log to tensorboard
                             if self.accelerator.is_main_process:
                                 if self.writer is not None:
                                     for key, value in loss_dict.items():
-                                        self.writer.add_scalar(f"{key}", value, self.step_num)
-                                    self.writer.add_scalar(f"lr", learning_rate, self.step_num)
+                                        self.writer.add_scalar(
+                                            f"{key}", value, self.step_num
+                                        )
+                                    self.writer.add_scalar(
+                                        f"lr", learning_rate, self.step_num
+                                    )
                                 if self.progress_bar is not None:
                                     self.progress_bar.unpause()
-                        
+
                         if self.accelerator.is_main_process:
                             # log to logger
-                            self.logger.log({
-                                'learning_rate': learning_rate,
-                            })
+                            self.logger.log(
+                                {
+                                    "learning_rate": learning_rate,
+                                }
+                            )
                             for key, value in loss_dict.items():
-                                self.logger.log({
-                                    f'loss/{key}': value,
-                                })
+                                self.logger.log(
+                                    {
+                                        f"loss/{key}": value,
+                                    }
+                                )
                     elif self.logging_config.log_every is None:
                         if self.accelerator.is_main_process:
                             # log every step
-                            self.logger.log({
-                                'learning_rate': learning_rate,
-                            })
+                            self.logger.log(
+                                {
+                                    "learning_rate": learning_rate,
+                                }
+                            )
                             for key, value in loss_dict.items():
-                                self.logger.log({
-                                    f'loss/{key}': value,
-                                })
+                                self.logger.log(
+                                    {
+                                        f"loss/{key}": value,
+                                    }
+                                )
 
-
-                    if self.performance_log_every > 0 and self.step_num % self.performance_log_every == 0:
+                    if (
+                        self.performance_log_every > 0
+                        and self.step_num % self.performance_log_every == 0
+                    ):
                         if self.progress_bar is not None:
                             self.progress_bar.pause()
                         # print the timers and clear them
@@ -2185,7 +2464,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         self.timer.reset()
                         if self.progress_bar is not None:
                             self.progress_bar.unpause()
-                
+
                 # commit log
                 if self.accelerator.is_main_process:
                     self.logger.commit(step=self.step_num)
@@ -2202,7 +2481,6 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 self.step_num = step + 1
                 self.grad_accumulation_step += 1
                 self.end_step_hook()
-
 
         ###################################################################
         ##  END TRAIN LOOP
@@ -2224,11 +2502,11 @@ class BaseSDTrainProcess(BaseTrainProcess):
         if self.accelerator.is_main_process:
             # push to hub
             if self.save_config.push_to_hub:
-                if("HF_TOKEN" not in os.environ):
+                if "HF_TOKEN" not in os.environ:
                     interpreter_login(new_session=False, write_permission=True)
                 self.push_to_hub(
                     repo_id=self.save_config.hf_repo_id,
-                    private=self.save_config.hf_private
+                    private=self.save_config.hf_private,
                 )
         del (
             self.sd,
@@ -2244,24 +2522,20 @@ class BaseSDTrainProcess(BaseTrainProcess):
         self.done_hook()
 
     def push_to_hub(
-    self,
-    repo_id: str,
-    private: bool = False,
-    ):  
+        self,
+        repo_id: str,
+        private: bool = False,
+    ):
         if not self.accelerator.is_main_process:
             return
         readme_content = self._generate_readme(repo_id)
         readme_path = os.path.join(self.save_root, "README.md")
         with open(readme_path, "w", encoding="utf-8") as f:
             f.write(readme_content)
-        
+
         api = HfApi()
 
-        api.create_repo(
-            repo_id,
-            private=private,
-            exist_ok=True
-        )
+        api.create_repo(repo_id, private=private, exist_ok=True)
 
         api.upload_folder(
             repo_id=repo_id,
@@ -2269,7 +2543,6 @@ class BaseSDTrainProcess(BaseTrainProcess):
             ignore_patterns=["*.yaml", "*.pt"],
             repo_type="model",
         )
-
 
     def _generate_readme(self, repo_id: str) -> str:
         """Generates the content of the README.md file."""
@@ -2312,19 +2585,19 @@ class BaseSDTrainProcess(BaseTrainProcess):
         samples_dir = os.path.join(self.save_root, "samples")
         if os.path.isdir(samples_dir):
             for filename in os.listdir(samples_dir):
-                #The filenames are structured as 1724085406830__00000500_0.jpg
-                #So here we capture the 2nd part (steps) and 3rd (index the matches the prompt)
+                # The filenames are structured as 1724085406830__00000500_0.jpg
+                # So here we capture the 2nd part (steps) and 3rd (index the matches the prompt)
                 match = re.search(r"__(\d+)_(\d+)\.jpg$", filename)
                 if match:
                     steps, index = int(match.group(1)), int(match.group(2))
-                    #Here we only care about uploading the latest samples, the match with the # of steps
+                    # Here we only care about uploading the latest samples, the match with the # of steps
                     if steps == self.train_config.steps:
                         sample_image_paths.append((index, f"samples/{filename}"))
 
             # Sort by numeric index
             sample_image_paths.sort(key=lambda x: x[0])
 
-            # Create widgets matching prompt with the index 
+            # Create widgets matching prompt with the index
             for i, prompt in enumerate(self.sample_config.prompts):
                 if i < len(sample_image_paths):
                     # Associate prompts with sample image paths based on the extracted index
@@ -2332,9 +2605,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     widgets.append(
                         {
                             "text": prompt,
-                            "output": {
-                                "url": image_path
-                            },
+                            "output": {"url": image_path},
                         }
                     )
         dtype = "torch.bfloat16" if self.model_config.is_flux else "torch.float16"

--- a/testing/test_bucket_dataloader.py
+++ b/testing/test_bucket_dataloader.py
@@ -15,17 +15,20 @@ import torchvision.transforms.functional
 from toolkit.image_utils import save_tensors, show_img, show_tensors
 
 from toolkit.data_transfer_object.data_loader import DataLoaderBatchDTO
-from toolkit.data_loader import AiToolkitDataset, get_dataloader_from_datasets, \
-    trigger_dataloader_setup_epoch
+from toolkit.data_loader import (
+    AiToolkitDataset,
+    get_dataloader_from_datasets,
+    trigger_dataloader_setup_epoch,
+)
 from toolkit.config_modules import DatasetConfig
 import argparse
 from tqdm import tqdm
 
 parser = argparse.ArgumentParser()
-parser.add_argument('dataset_folder', type=str, default='input')
-parser.add_argument('--epochs', type=int, default=1)
-parser.add_argument('--num_frames', type=int, default=1)
-parser.add_argument('--output_path', type=str, default=None)
+parser.add_argument("dataset_folder", type=str, default="input")
+parser.add_argument("--epochs", type=int, default=1)
+parser.add_argument("--num_frames", type=int, default=1)
+parser.add_argument("--output_path", type=str, default=None)
 
 
 args = parser.parse_args()
@@ -41,6 +44,7 @@ batch_size = 1
 
 clip_processor = CLIPImageProcessor.from_pretrained("openai/clip-vit-base-patch16")
 
+
 class FakeAdapter:
     def __init__(self):
         self.clip_image_processor = clip_processor
@@ -52,15 +56,13 @@ class FakeSD:
         self.adapter = FakeAdapter()
 
 
-
-
 dataset_config = DatasetConfig(
     dataset_path=dataset_folder,
     # clip_image_path=dataset_folder,
     # square_crop=True,
     resolution=resolution,
     # caption_ext='json',
-    default_caption='default',
+    default_caption="default",
     # clip_image_path='/mnt/Datasets2/regs/yetibear_xl_v14/random_aspect/',
     buckets=True,
     bucket_tolerance=bucket_tolerance,
@@ -78,7 +80,9 @@ dataset_config = DatasetConfig(
     # ]
 )
 
-dataloader: DataLoader = get_dataloader_from_datasets([dataset_config], batch_size=batch_size, sd=FakeSD())
+dataloader = get_dataloader_from_datasets(
+    [dataset_config], batch_size=batch_size, sd=FakeSD()
+)[0]
 
 
 # run through an epoch ang check sizes
@@ -86,7 +90,7 @@ dataloader_iterator = iter(dataloader)
 idx = 0
 for epoch in range(args.epochs):
     for batch in tqdm(dataloader):
-        batch: 'DataLoaderBatchDTO'
+        batch: "DataLoaderBatchDTO"
         img_batch = batch.tensor
         frames = 1
         if len(img_batch.shape) == 5:
@@ -120,7 +124,7 @@ for epoch in range(args.epochs):
         big_img = img_batch
         # big_img = big_img.clamp(-1, 1)
         if args.output_path is not None:
-            save_tensors(big_img, os.path.join(args.output_path, f'{idx}.png'))
+            save_tensors(big_img, os.path.join(args.output_path, f"{idx}.png"))
         else:
             show_tensors(big_img)
 
@@ -137,4 +141,4 @@ for epoch in range(args.epochs):
 
 cv2.destroyAllWindows()
 
-print('done')
+print("done")

--- a/toolkit/config_modules.py
+++ b/toolkit/config_modules.py
@@ -7,9 +7,9 @@ import torch
 
 from toolkit.prompt_utils import PromptEmbeds
 
-ImgExt = Literal['jpg', 'png', 'webp']
+ImgExt = Literal["jpg", "png", "webp"]
 
-SaveFormat = Literal['safetensors', 'diffusers']
+SaveFormat = Literal["safetensors", "diffusers"]
 
 if TYPE_CHECKING:
     from toolkit.guidance import GuidanceType
@@ -17,495 +17,586 @@ if TYPE_CHECKING:
 else:
     EmptyLogger = None
 
+
 class SaveConfig:
     def __init__(self, **kwargs):
-        self.save_every: int = kwargs.get('save_every', 1000)
-        self.dtype: str = kwargs.get('dtype', 'float16')
-        self.max_step_saves_to_keep: int = kwargs.get('max_step_saves_to_keep', 5)
-        self.save_format: SaveFormat = kwargs.get('save_format', 'safetensors')
-        if self.save_format not in ['safetensors', 'diffusers']:
-            raise ValueError(f"save_format must be safetensors or diffusers, got {self.save_format}")
+        self.save_every: int = kwargs.get("save_every", 1000)
+        self.dtype: str = kwargs.get("dtype", "float16")
+        self.max_step_saves_to_keep: int = kwargs.get("max_step_saves_to_keep", 5)
+        self.save_format: SaveFormat = kwargs.get("save_format", "safetensors")
+        if self.save_format not in ["safetensors", "diffusers"]:
+            raise ValueError(
+                f"save_format must be safetensors or diffusers, got {self.save_format}"
+            )
         self.push_to_hub: bool = kwargs.get("push_to_hub", False)
         self.hf_repo_id: Optional[str] = kwargs.get("hf_repo_id", None)
         self.hf_private: Optional[str] = kwargs.get("hf_private", False)
 
+
 class LoggingConfig:
     def __init__(self, **kwargs):
-        self.log_every: int = kwargs.get('log_every', 100)
-        self.verbose: bool = kwargs.get('verbose', False)
-        self.use_wandb: bool = kwargs.get('use_wandb', False)
-        self.project_name: str = kwargs.get('project_name', 'ai-toolkit')
-        self.run_name: str = kwargs.get('run_name', None)
+        self.log_every: int = kwargs.get("log_every", 100)
+        self.verbose: bool = kwargs.get("verbose", False)
+        self.use_wandb: bool = kwargs.get("use_wandb", False)
+        self.project_name: str = kwargs.get("project_name", "ai-toolkit")
+        self.run_name: str = kwargs.get("run_name", None)
 
 
 class SampleConfig:
     def __init__(self, **kwargs):
-        self.sampler: str = kwargs.get('sampler', 'ddpm')
-        self.sample_every: int = kwargs.get('sample_every', 100)
-        self.width: int = kwargs.get('width', 512)
-        self.height: int = kwargs.get('height', 512)
-        self.prompts: list[str] = kwargs.get('prompts', [])
-        self.neg = kwargs.get('neg', False)
-        self.seed = kwargs.get('seed', 0)
-        self.walk_seed = kwargs.get('walk_seed', False)
-        self.guidance_scale = kwargs.get('guidance_scale', 7)
-        self.sample_steps = kwargs.get('sample_steps', 20)
-        self.network_multiplier = kwargs.get('network_multiplier', 1)
-        self.guidance_rescale = kwargs.get('guidance_rescale', 0.0)
-        self.ext: ImgExt = kwargs.get('format', 'jpg')
-        self.adapter_conditioning_scale = kwargs.get('adapter_conditioning_scale', 1.0)
-        self.refiner_start_at = kwargs.get('refiner_start_at',
-                                           0.5)  # step to start using refiner on sample if it exists
-        self.extra_values = kwargs.get('extra_values', [])
-        self.num_frames = kwargs.get('num_frames', 1)
-        self.fps: int = kwargs.get('fps', 16)
-        if self.num_frames > 1 and self.ext not in ['webp']:
+        self.sampler: str = kwargs.get("sampler", "ddpm")
+        self.sample_every: int = kwargs.get("sample_every", 100)
+        self.width: int = kwargs.get("width", 512)
+        self.height: int = kwargs.get("height", 512)
+        self.prompts: list[str] = kwargs.get("prompts", [])
+        self.neg = kwargs.get("neg", False)
+        self.seed = kwargs.get("seed", 0)
+        self.walk_seed = kwargs.get("walk_seed", False)
+        self.guidance_scale = kwargs.get("guidance_scale", 7)
+        self.sample_steps = kwargs.get("sample_steps", 20)
+        self.network_multiplier = kwargs.get("network_multiplier", 1)
+        self.guidance_rescale = kwargs.get("guidance_rescale", 0.0)
+        self.ext: ImgExt = kwargs.get("format", "jpg")
+        self.adapter_conditioning_scale = kwargs.get("adapter_conditioning_scale", 1.0)
+        self.refiner_start_at = kwargs.get(
+            "refiner_start_at", 0.5
+        )  # step to start using refiner on sample if it exists
+        self.extra_values = kwargs.get("extra_values", [])
+        self.num_frames = kwargs.get("num_frames", 1)
+        self.fps: int = kwargs.get("fps", 16)
+        if self.num_frames > 1 and self.ext not in ["webp"]:
             print("Changing sample extention to animated webp")
-            self.ext = 'webp'
+            self.ext = "webp"
 
 
 class LormModuleSettingsConfig:
     def __init__(self, **kwargs):
-        self.contains: str = kwargs.get('contains', '4nt$3')
-        self.extract_mode: str = kwargs.get('extract_mode', 'ratio')
+        self.contains: str = kwargs.get("contains", "4nt$3")
+        self.extract_mode: str = kwargs.get("extract_mode", "ratio")
         # min num parameters to attach to
-        self.parameter_threshold: int = kwargs.get('parameter_threshold', 0)
-        self.extract_mode_param: dict = kwargs.get('extract_mode_param', 0.25)
+        self.parameter_threshold: int = kwargs.get("parameter_threshold", 0)
+        self.extract_mode_param: dict = kwargs.get("extract_mode_param", 0.25)
 
 
 class LoRMConfig:
     def __init__(self, **kwargs):
-        self.extract_mode: str = kwargs.get('extract_mode', 'ratio')
-        self.do_conv: bool = kwargs.get('do_conv', False)
-        self.extract_mode_param: dict = kwargs.get('extract_mode_param', 0.25)
-        self.parameter_threshold: int = kwargs.get('parameter_threshold', 0)
-        module_settings = kwargs.get('module_settings', [])
+        self.extract_mode: str = kwargs.get("extract_mode", "ratio")
+        self.do_conv: bool = kwargs.get("do_conv", False)
+        self.extract_mode_param: dict = kwargs.get("extract_mode_param", 0.25)
+        self.parameter_threshold: int = kwargs.get("parameter_threshold", 0)
+        module_settings = kwargs.get("module_settings", [])
         default_module_settings = {
-            'extract_mode': self.extract_mode,
-            'extract_mode_param': self.extract_mode_param,
-            'parameter_threshold': self.parameter_threshold,
+            "extract_mode": self.extract_mode,
+            "extract_mode_param": self.extract_mode_param,
+            "parameter_threshold": self.parameter_threshold,
         }
-        module_settings = [{**default_module_settings, **module_setting, } for module_setting in module_settings]
-        self.module_settings: List[LormModuleSettingsConfig] = [LormModuleSettingsConfig(**module_setting) for
-                                                                module_setting in module_settings]
+        module_settings = [
+            {
+                **default_module_settings,
+                **module_setting,
+            }
+            for module_setting in module_settings
+        ]
+        self.module_settings: List[LormModuleSettingsConfig] = [
+            LormModuleSettingsConfig(**module_setting)
+            for module_setting in module_settings
+        ]
 
     def get_config_for_module(self, block_name):
         for setting in self.module_settings:
-            contain_pieces = setting.contains.split('|')
+            contain_pieces = setting.contains.split("|")
             if all(contain_piece in block_name for contain_piece in contain_pieces):
                 return setting
             # try replacing the . with _
-            contain_pieces = setting.contains.replace('.', '_').split('|')
+            contain_pieces = setting.contains.replace(".", "_").split("|")
             if all(contain_piece in block_name for contain_piece in contain_pieces):
                 return setting
             # do default
-        return LormModuleSettingsConfig(**{
-            'extract_mode': self.extract_mode,
-            'extract_mode_param': self.extract_mode_param,
-            'parameter_threshold': self.parameter_threshold,
-        })
+        return LormModuleSettingsConfig(
+            **{
+                "extract_mode": self.extract_mode,
+                "extract_mode_param": self.extract_mode_param,
+                "parameter_threshold": self.parameter_threshold,
+            }
+        )
 
 
-NetworkType = Literal['lora', 'locon', 'lorm', 'lokr']
+NetworkType = Literal["lora", "locon", "lorm", "lokr"]
 
 
 class NetworkConfig:
     def __init__(self, **kwargs):
-        self.type: NetworkType = kwargs.get('type', 'lora')
-        rank = kwargs.get('rank', None)
-        linear = kwargs.get('linear', None)
+        self.type: NetworkType = kwargs.get("type", "lora")
+        rank = kwargs.get("rank", None)
+        linear = kwargs.get("linear", None)
         if rank is not None:
             self.rank: int = rank  # rank for backward compatibility
             self.linear: int = rank
         elif linear is not None:
             self.rank: int = linear
             self.linear: int = linear
-        self.conv: int = kwargs.get('conv', None)
-        self.alpha: float = kwargs.get('alpha', 1.0)
-        self.linear_alpha: float = kwargs.get('linear_alpha', self.alpha)
-        self.conv_alpha: float = kwargs.get('conv_alpha', self.conv)
-        self.dropout: Union[float, None] = kwargs.get('dropout', None)
-        self.network_kwargs: dict = kwargs.get('network_kwargs', {})
+        self.conv: int = kwargs.get("conv", None)
+        self.alpha: float = kwargs.get("alpha", 1.0)
+        self.linear_alpha: float = kwargs.get("linear_alpha", self.alpha)
+        self.conv_alpha: float = kwargs.get("conv_alpha", self.conv)
+        self.dropout: Union[float, None] = kwargs.get("dropout", None)
+        self.network_kwargs: dict = kwargs.get("network_kwargs", {})
 
         self.lorm_config: Union[LoRMConfig, None] = None
-        lorm = kwargs.get('lorm', None)
+        lorm = kwargs.get("lorm", None)
         if lorm is not None:
             self.lorm_config: LoRMConfig = LoRMConfig(**lorm)
 
-        if self.type == 'lorm':
+        if self.type == "lorm":
             # set linear to arbitrary values so it makes them
             self.linear = 4
             self.rank = 4
             if self.lorm_config.do_conv:
                 self.conv = 4
 
-        self.transformer_only = kwargs.get('transformer_only', True)
-        
-        self.lokr_full_rank = kwargs.get('lokr_full_rank', False)
-        if self.lokr_full_rank and self.type.lower() == 'lokr':
+        self.transformer_only = kwargs.get("transformer_only", True)
+
+        self.lokr_full_rank = kwargs.get("lokr_full_rank", False)
+        if self.lokr_full_rank and self.type.lower() == "lokr":
             self.linear = 9999999999
             self.linear_alpha = 9999999999
             self.conv = 9999999999
             self.conv_alpha = 9999999999
         # -1 automatically finds the largest factor
-        self.lokr_factor = kwargs.get('lokr_factor', -1)
+        self.lokr_factor = kwargs.get("lokr_factor", -1)
 
 
-AdapterTypes = Literal['t2i', 'ip', 'ip+', 'clip', 'ilora', 'photo_maker', 'control_net', 'control_lora', 'i2v']
+AdapterTypes = Literal[
+    "t2i",
+    "ip",
+    "ip+",
+    "clip",
+    "ilora",
+    "photo_maker",
+    "control_net",
+    "control_lora",
+    "i2v",
+]
 
-CLIPLayer = Literal['penultimate_hidden_states', 'image_embeds', 'last_hidden_state']
+CLIPLayer = Literal["penultimate_hidden_states", "image_embeds", "last_hidden_state"]
 
 
 class AdapterConfig:
     def __init__(self, **kwargs):
-        self.type: AdapterTypes = kwargs.get('type', 't2i')  # t2i, ip, clip, control_net, i2v
-        self.in_channels: int = kwargs.get('in_channels', 3)
-        self.channels: List[int] = kwargs.get('channels', [320, 640, 1280, 1280])
-        self.num_res_blocks: int = kwargs.get('num_res_blocks', 2)
-        self.downscale_factor: int = kwargs.get('downscale_factor', 8)
-        self.adapter_type: str = kwargs.get('adapter_type', 'full_adapter')
-        self.image_dir: str = kwargs.get('image_dir', None)
-        self.test_img_path: List[str] = kwargs.get('test_img_path', None)
+        self.type: AdapterTypes = kwargs.get(
+            "type", "t2i"
+        )  # t2i, ip, clip, control_net, i2v
+        self.in_channels: int = kwargs.get("in_channels", 3)
+        self.channels: List[int] = kwargs.get("channels", [320, 640, 1280, 1280])
+        self.num_res_blocks: int = kwargs.get("num_res_blocks", 2)
+        self.downscale_factor: int = kwargs.get("downscale_factor", 8)
+        self.adapter_type: str = kwargs.get("adapter_type", "full_adapter")
+        self.image_dir: str = kwargs.get("image_dir", None)
+        self.test_img_path: List[str] = kwargs.get("test_img_path", None)
         if self.test_img_path is not None:
             if isinstance(self.test_img_path, str):
-                self.test_img_path = self.test_img_path.split(',')
+                self.test_img_path = self.test_img_path.split(",")
                 self.test_img_path = [p.strip() for p in self.test_img_path]
-                self.test_img_path = [p for p in self.test_img_path if p != '']
-                
-        self.train: str = kwargs.get('train', False)
-        self.image_encoder_path: str = kwargs.get('image_encoder_path', None)
-        self.name_or_path = kwargs.get('name_or_path', None)
+                self.test_img_path = [p for p in self.test_img_path if p != ""]
 
-        num_tokens = kwargs.get('num_tokens', None)
-        if num_tokens is None and self.type.startswith('ip'):
-            if self.type == 'ip+':
+        self.train: str = kwargs.get("train", False)
+        self.image_encoder_path: str = kwargs.get("image_encoder_path", None)
+        self.name_or_path = kwargs.get("name_or_path", None)
+
+        num_tokens = kwargs.get("num_tokens", None)
+        if num_tokens is None and self.type.startswith("ip"):
+            if self.type == "ip+":
                 num_tokens = 16
                 num_tokens = 16
-            elif self.type == 'ip':
+            elif self.type == "ip":
                 num_tokens = 4
 
         self.num_tokens: int = num_tokens
-        self.train_image_encoder: bool = kwargs.get('train_image_encoder', False)
-        self.train_only_image_encoder: bool = kwargs.get('train_only_image_encoder', False)
+        self.train_image_encoder: bool = kwargs.get("train_image_encoder", False)
+        self.train_only_image_encoder: bool = kwargs.get(
+            "train_only_image_encoder", False
+        )
         if self.train_only_image_encoder:
             self.train_image_encoder = True
         self.train_only_image_encoder_positional_embedding: bool = kwargs.get(
-            'train_only_image_encoder_positional_embedding', False)
-        self.image_encoder_arch: str = kwargs.get('image_encoder_arch', 'clip')  # clip vit vit_hybrid, safe
-        self.safe_reducer_channels: int = kwargs.get('safe_reducer_channels', 512)
-        self.safe_channels: int = kwargs.get('safe_channels', 2048)
-        self.safe_tokens: int = kwargs.get('safe_tokens', 8)
-        self.quad_image: bool = kwargs.get('quad_image', False)
+            "train_only_image_encoder_positional_embedding", False
+        )
+        self.image_encoder_arch: str = kwargs.get(
+            "image_encoder_arch", "clip"
+        )  # clip vit vit_hybrid, safe
+        self.safe_reducer_channels: int = kwargs.get("safe_reducer_channels", 512)
+        self.safe_channels: int = kwargs.get("safe_channels", 2048)
+        self.safe_tokens: int = kwargs.get("safe_tokens", 8)
+        self.quad_image: bool = kwargs.get("quad_image", False)
 
         # clip vision
-        self.trigger = kwargs.get('trigger', 'tri993r')
-        self.trigger_class_name = kwargs.get('trigger_class_name', None)
+        self.trigger = kwargs.get("trigger", "tri993r")
+        self.trigger_class_name = kwargs.get("trigger_class_name", None)
 
-        self.class_names = kwargs.get('class_names', [])
+        self.class_names = kwargs.get("class_names", [])
 
-        self.clip_layer: CLIPLayer = kwargs.get('clip_layer', None)
+        self.clip_layer: CLIPLayer = kwargs.get("clip_layer", None)
         if self.clip_layer is None:
-            if self.type.startswith('ip+'):
-                self.clip_layer = 'penultimate_hidden_states'
+            if self.type.startswith("ip+"):
+                self.clip_layer = "penultimate_hidden_states"
             else:
-                self.clip_layer = 'last_hidden_state'
+                self.clip_layer = "last_hidden_state"
 
         # text encoder
-        self.text_encoder_path: str = kwargs.get('text_encoder_path', None)
-        self.text_encoder_arch: str = kwargs.get('text_encoder_arch', 'clip')  # clip t5
+        self.text_encoder_path: str = kwargs.get("text_encoder_path", None)
+        self.text_encoder_arch: str = kwargs.get("text_encoder_arch", "clip")  # clip t5
 
-        self.train_scaler: bool = kwargs.get('train_scaler', False)
-        self.scaler_lr: Optional[float] = kwargs.get('scaler_lr', None)
+        self.train_scaler: bool = kwargs.get("train_scaler", False)
+        self.scaler_lr: Optional[float] = kwargs.get("scaler_lr", None)
 
         # trains with a scaler to easy channel bias but merges it in on save
-        self.merge_scaler: bool = kwargs.get('merge_scaler', False)
+        self.merge_scaler: bool = kwargs.get("merge_scaler", False)
 
         # for ilora
-        self.head_dim: int = kwargs.get('head_dim', 1024)
-        self.num_heads: int = kwargs.get('num_heads', 1)
-        self.ilora_down: bool = kwargs.get('ilora_down', True)
-        self.ilora_mid: bool = kwargs.get('ilora_mid', True)
-        self.ilora_up: bool = kwargs.get('ilora_up', True)
-        
-        self.pixtral_max_image_size: int = kwargs.get('pixtral_max_image_size', 512)
-        self.pixtral_random_image_size: int = kwargs.get('pixtral_random_image_size', False)
+        self.head_dim: int = kwargs.get("head_dim", 1024)
+        self.num_heads: int = kwargs.get("num_heads", 1)
+        self.ilora_down: bool = kwargs.get("ilora_down", True)
+        self.ilora_mid: bool = kwargs.get("ilora_mid", True)
+        self.ilora_up: bool = kwargs.get("ilora_up", True)
 
-        self.flux_only_double: bool = kwargs.get('flux_only_double', False)
-        
+        self.pixtral_max_image_size: int = kwargs.get("pixtral_max_image_size", 512)
+        self.pixtral_random_image_size: int = kwargs.get(
+            "pixtral_random_image_size", False
+        )
+
+        self.flux_only_double: bool = kwargs.get("flux_only_double", False)
+
         # train and use a conv layer to pool the embedding
-        self.conv_pooling: bool = kwargs.get('conv_pooling', False)
-        self.conv_pooling_stacks: int = kwargs.get('conv_pooling_stacks', 1)
-        self.sparse_autoencoder_dim: Optional[int] = kwargs.get('sparse_autoencoder_dim', None)
-        
+        self.conv_pooling: bool = kwargs.get("conv_pooling", False)
+        self.conv_pooling_stacks: int = kwargs.get("conv_pooling_stacks", 1)
+        self.sparse_autoencoder_dim: Optional[int] = kwargs.get(
+            "sparse_autoencoder_dim", None
+        )
+
         # for llm adapter
-        self.num_cloned_blocks: int = kwargs.get('num_cloned_blocks', 0)
-        self.quantize_llm: bool = kwargs.get('quantize_llm', False)
-        
+        self.num_cloned_blocks: int = kwargs.get("num_cloned_blocks", 0)
+        self.quantize_llm: bool = kwargs.get("quantize_llm", False)
+
         # for control lora only
-        lora_config: dict = kwargs.get('lora_config', None)
+        lora_config: dict = kwargs.get("lora_config", None)
         if lora_config is not None:
             self.lora_config: NetworkConfig = NetworkConfig(**lora_config)
         else:
             self.lora_config = None
-        self.num_control_images: int = kwargs.get('num_control_images', 1)
+        self.num_control_images: int = kwargs.get("num_control_images", 1)
         # decimal for how often the control is dropped out and replaced with noise 1.0 is 100%
-        self.control_image_dropout: float = kwargs.get('control_image_dropout', 0.0)
-        self.has_inpainting_input: bool = kwargs.get('has_inpainting_input', False)
-        self.invert_inpaint_mask_chance: float = kwargs.get('invert_inpaint_mask_chance', 0.0)
-        
+        self.control_image_dropout: float = kwargs.get("control_image_dropout", 0.0)
+        self.has_inpainting_input: bool = kwargs.get("has_inpainting_input", False)
+        self.invert_inpaint_mask_chance: float = kwargs.get(
+            "invert_inpaint_mask_chance", 0.0
+        )
+
         # for subpixel adapter
-        self.subpixel_downscale_factor: int = kwargs.get('subpixel_downscale_factor', 8)
-        
+        self.subpixel_downscale_factor: int = kwargs.get("subpixel_downscale_factor", 8)
+
         # for i2v adapter
         # append the masked start frame. During pretraining we will only do the vision encoder
-        self.i2v_do_start_frame: bool = kwargs.get('i2v_do_start_frame', False)
+        self.i2v_do_start_frame: bool = kwargs.get("i2v_do_start_frame", False)
 
 
 class EmbeddingConfig:
     def __init__(self, **kwargs):
-        self.trigger = kwargs.get('trigger', 'custom_embedding')
-        self.tokens = kwargs.get('tokens', 4)
-        self.init_words = kwargs.get('init_words', '*')
-        self.save_format = kwargs.get('save_format', 'safetensors')
-        self.trigger_class_name = kwargs.get('trigger_class_name', None)  # used for inverted masked prior
+        self.trigger = kwargs.get("trigger", "custom_embedding")
+        self.tokens = kwargs.get("tokens", 4)
+        self.init_words = kwargs.get("init_words", "*")
+        self.save_format = kwargs.get("save_format", "safetensors")
+        self.trigger_class_name = kwargs.get(
+            "trigger_class_name", None
+        )  # used for inverted masked prior
 
 
 class DecoratorConfig:
     def __init__(self, **kwargs):
-        self.num_tokens: str = kwargs.get('num_tokens', 4)
+        self.num_tokens: str = kwargs.get("num_tokens", 4)
 
 
-ContentOrStyleType = Literal['balanced', 'style', 'content']
-LossTarget = Literal['noise', 'source', 'unaugmented', 'differential_noise']
+ContentOrStyleType = Literal["balanced", "style", "content"]
+LossTarget = Literal["noise", "source", "unaugmented", "differential_noise"]
 
 
 class TrainConfig:
     def __init__(self, **kwargs):
-        self.noise_scheduler = kwargs.get('noise_scheduler', 'ddpm')
-        self.content_or_style: ContentOrStyleType = kwargs.get('content_or_style', 'balanced')
-        self.content_or_style_reg: ContentOrStyleType = kwargs.get('content_or_style', 'balanced')
-        self.steps: int = kwargs.get('steps', 1000)
-        self.lr = kwargs.get('lr', 1e-6)
-        self.unet_lr = kwargs.get('unet_lr', self.lr)
-        self.text_encoder_lr = kwargs.get('text_encoder_lr', self.lr)
-        self.refiner_lr = kwargs.get('refiner_lr', self.lr)
-        self.embedding_lr = kwargs.get('embedding_lr', self.lr)
-        self.adapter_lr = kwargs.get('adapter_lr', self.lr)
-        self.optimizer = kwargs.get('optimizer', 'adamw')
-        self.optimizer_params = kwargs.get('optimizer_params', {})
-        self.lr_scheduler = kwargs.get('lr_scheduler', 'constant')
-        self.lr_scheduler_params = kwargs.get('lr_scheduler_params', {})
-        self.min_denoising_steps: int = kwargs.get('min_denoising_steps', 0)
-        self.max_denoising_steps: int = kwargs.get('max_denoising_steps', 1000)
-        self.batch_size: int = kwargs.get('batch_size', 1)
+        self.noise_scheduler = kwargs.get("noise_scheduler", "ddpm")
+        self.content_or_style: ContentOrStyleType = kwargs.get(
+            "content_or_style", "balanced"
+        )
+        self.content_or_style_reg: ContentOrStyleType = kwargs.get(
+            "content_or_style", "balanced"
+        )
+        self.steps: int = kwargs.get("steps", 1000)
+        self.lr = kwargs.get("lr", 1e-6)
+        self.unet_lr = kwargs.get("unet_lr", self.lr)
+        self.text_encoder_lr = kwargs.get("text_encoder_lr", self.lr)
+        self.refiner_lr = kwargs.get("refiner_lr", self.lr)
+        self.embedding_lr = kwargs.get("embedding_lr", self.lr)
+        self.adapter_lr = kwargs.get("adapter_lr", self.lr)
+        self.optimizer = kwargs.get("optimizer", "adamw")
+        self.optimizer_params = kwargs.get("optimizer_params", {})
+        self.lr_scheduler = kwargs.get("lr_scheduler", "constant")
+        self.lr_scheduler_params = kwargs.get("lr_scheduler_params", {})
+        self.min_denoising_steps: int = kwargs.get("min_denoising_steps", 0)
+        self.max_denoising_steps: int = kwargs.get("max_denoising_steps", 1000)
+        self.batch_size: int = kwargs.get("batch_size", 1)
         self.orig_batch_size: int = self.batch_size
-        self.dtype: str = kwargs.get('dtype', 'fp32')
-        self.xformers = kwargs.get('xformers', False)
-        self.sdp = kwargs.get('sdp', False)
-        self.train_unet = kwargs.get('train_unet', True)
-        self.train_text_encoder = kwargs.get('train_text_encoder', False)
-        self.train_refiner = kwargs.get('train_refiner', True)
-        self.train_turbo = kwargs.get('train_turbo', False)
-        self.show_turbo_outputs = kwargs.get('show_turbo_outputs', False)
-        self.min_snr_gamma = kwargs.get('min_snr_gamma', None)
-        self.snr_gamma = kwargs.get('snr_gamma', None)
+        self.dtype: str = kwargs.get("dtype", "fp32")
+        self.xformers = kwargs.get("xformers", False)
+        self.sdp = kwargs.get("sdp", False)
+        self.train_unet = kwargs.get("train_unet", True)
+        self.train_text_encoder = kwargs.get("train_text_encoder", False)
+        self.train_refiner = kwargs.get("train_refiner", True)
+        self.train_turbo = kwargs.get("train_turbo", False)
+        self.show_turbo_outputs = kwargs.get("show_turbo_outputs", False)
+        self.min_snr_gamma = kwargs.get("min_snr_gamma", None)
+        self.snr_gamma = kwargs.get("snr_gamma", None)
         # trains a gamma, offset, and scale to adjust loss to adapt to timestep differentials
         # this should balance the learning rate across all timesteps over time
-        self.learnable_snr_gos = kwargs.get('learnable_snr_gos', False)
-        self.noise_offset = kwargs.get('noise_offset', 0.0)
-        self.skip_first_sample = kwargs.get('skip_first_sample', False)
-        self.force_first_sample = kwargs.get('force_first_sample', False)
-        self.gradient_checkpointing = kwargs.get('gradient_checkpointing', True)
-        self.weight_jitter = kwargs.get('weight_jitter', 0.0)
-        self.merge_network_on_save = kwargs.get('merge_network_on_save', False)
-        self.max_grad_norm = kwargs.get('max_grad_norm', 1.0)
-        self.start_step = kwargs.get('start_step', None)
-        self.free_u = kwargs.get('free_u', False)
-        self.adapter_assist_name_or_path: Optional[str] = kwargs.get('adapter_assist_name_or_path', None)
-        self.adapter_assist_type: Optional[str] = kwargs.get('adapter_assist_type', 't2i')  # t2i, control_net
-        self.noise_multiplier = kwargs.get('noise_multiplier', 1.0)
-        self.target_noise_multiplier = kwargs.get('target_noise_multiplier', 1.0)
-        self.random_noise_multiplier = kwargs.get('random_noise_multiplier', 0.0)
-        self.random_noise_shift = kwargs.get('random_noise_shift', 0.0)
-        self.img_multiplier = kwargs.get('img_multiplier', 1.0)
-        self.noisy_latent_multiplier = kwargs.get('noisy_latent_multiplier', 1.0)
-        self.latent_multiplier = kwargs.get('latent_multiplier', 1.0)
-        self.negative_prompt = kwargs.get('negative_prompt', None)
-        self.max_negative_prompts = kwargs.get('max_negative_prompts', 1)
+        self.learnable_snr_gos = kwargs.get("learnable_snr_gos", False)
+        self.noise_offset = kwargs.get("noise_offset", 0.0)
+        self.skip_first_sample = kwargs.get("skip_first_sample", False)
+        self.force_first_sample = kwargs.get("force_first_sample", False)
+        self.gradient_checkpointing = kwargs.get("gradient_checkpointing", True)
+        self.weight_jitter = kwargs.get("weight_jitter", 0.0)
+        self.merge_network_on_save = kwargs.get("merge_network_on_save", False)
+        self.max_grad_norm = kwargs.get("max_grad_norm", 1.0)
+        self.start_step = kwargs.get("start_step", None)
+        self.free_u = kwargs.get("free_u", False)
+        self.adapter_assist_name_or_path: Optional[str] = kwargs.get(
+            "adapter_assist_name_or_path", None
+        )
+        self.adapter_assist_type: Optional[str] = kwargs.get(
+            "adapter_assist_type", "t2i"
+        )  # t2i, control_net
+        self.noise_multiplier = kwargs.get("noise_multiplier", 1.0)
+        self.target_noise_multiplier = kwargs.get("target_noise_multiplier", 1.0)
+        self.random_noise_multiplier = kwargs.get("random_noise_multiplier", 0.0)
+        self.random_noise_shift = kwargs.get("random_noise_shift", 0.0)
+        self.img_multiplier = kwargs.get("img_multiplier", 1.0)
+        self.noisy_latent_multiplier = kwargs.get("noisy_latent_multiplier", 1.0)
+        self.latent_multiplier = kwargs.get("latent_multiplier", 1.0)
+        self.negative_prompt = kwargs.get("negative_prompt", None)
+        self.max_negative_prompts = kwargs.get("max_negative_prompts", 1)
         # multiplier applied to loos on regularization images
-        self.reg_weight = kwargs.get('reg_weight', 1.0)
-        self.num_train_timesteps = kwargs.get('num_train_timesteps', 1000)
+        self.reg_weight = kwargs.get("reg_weight", 1.0)
+        self.num_train_timesteps = kwargs.get("num_train_timesteps", 1000)
         # automatically adapte the vae scaling based on the image norm
-        self.adaptive_scaling_factor = kwargs.get('adaptive_scaling_factor', False)
+        self.adaptive_scaling_factor = kwargs.get("adaptive_scaling_factor", False)
 
         # dropout that happens before encoding. It functions independently per text encoder
-        self.prompt_dropout_prob = kwargs.get('prompt_dropout_prob', 0.0)
+        self.prompt_dropout_prob = kwargs.get("prompt_dropout_prob", 0.0)
 
         # match the norm of the noise before computing loss. This will help the model maintain its
         # current understandin of the brightness of images.
 
-        self.match_noise_norm = kwargs.get('match_noise_norm', False)
+        self.match_noise_norm = kwargs.get("match_noise_norm", False)
 
         # set to -1 to accumulate gradients for entire epoch
         # warning, only do this with a small dataset or you will run out of memory
         # This is legacy but left in for backwards compatibility
-        self.gradient_accumulation_steps = kwargs.get('gradient_accumulation_steps', 1)
+        self.gradient_accumulation_steps = kwargs.get("gradient_accumulation_steps", 1)
 
         # this will do proper gradient accumulation where you will not see a step until the end of the accumulation
         # the method above will show a step every accumulation
-        self.gradient_accumulation = kwargs.get('gradient_accumulation', 1)
+        self.gradient_accumulation = kwargs.get("gradient_accumulation", 1)
         if self.gradient_accumulation > 1:
             if self.gradient_accumulation_steps != 1:
-                raise ValueError("gradient_accumulation and gradient_accumulation_steps are mutually exclusive")
+                raise ValueError(
+                    "gradient_accumulation and gradient_accumulation_steps are mutually exclusive"
+                )
 
         # short long captions will double your batch size. This only works when a dataset is
         # prepared with a json caption file that has both short and long captions in it. It will
         # Double up every image and run it through with both short and long captions. The idea
         # is that the network will learn how to generate good images with both short and long captions
-        self.short_and_long_captions = kwargs.get('short_and_long_captions', False)
+        self.short_and_long_captions = kwargs.get("short_and_long_captions", False)
         # if above is NOT true, this will make it so the long caption foes to te2 and the short caption goes to te1 for sdxl only
-        self.short_and_long_captions_encoder_split = kwargs.get('short_and_long_captions_encoder_split', False)
+        self.short_and_long_captions_encoder_split = kwargs.get(
+            "short_and_long_captions_encoder_split", False
+        )
 
         # basically gradient accumulation but we run just 1 item through the network
         # and accumulate gradients. This can be used as basic gradient accumulation but is very helpful
         # for training tricks that increase batch size but need a single gradient step
-        self.single_item_batching = kwargs.get('single_item_batching', False)
+        self.single_item_batching = kwargs.get("single_item_batching", False)
 
-        match_adapter_assist = kwargs.get('match_adapter_assist', False)
-        self.match_adapter_chance = kwargs.get('match_adapter_chance', 0.0)
-        self.loss_target: LossTarget = kwargs.get('loss_target',
-                                                  'noise')  # noise, source, unaugmented, differential_noise
+        match_adapter_assist = kwargs.get("match_adapter_assist", False)
+        self.match_adapter_chance = kwargs.get("match_adapter_chance", 0.0)
+        self.loss_target: LossTarget = kwargs.get(
+            "loss_target", "noise"
+        )  # noise, source, unaugmented, differential_noise
 
         # When a mask is passed in a dataset, and this is true,
         # we will predict noise without a the LoRa network and use the prediction as a target for
         # unmasked reign. It is unmasked regularization basically
-        self.inverted_mask_prior = kwargs.get('inverted_mask_prior', False)
-        self.inverted_mask_prior_multiplier = kwargs.get('inverted_mask_prior_multiplier', 0.5)
-        
+        self.inverted_mask_prior = kwargs.get("inverted_mask_prior", False)
+        self.inverted_mask_prior_multiplier = kwargs.get(
+            "inverted_mask_prior_multiplier", 0.5
+        )
+
         # DOP will will run the same image and prompt through the network without the trigger word blank and use it as a target
-        self.diff_output_preservation = kwargs.get('diff_output_preservation', False)
-        self.diff_output_preservation_multiplier = kwargs.get('diff_output_preservation_multiplier', 1.0)
+        self.diff_output_preservation = kwargs.get("diff_output_preservation", False)
+        self.diff_output_preservation_multiplier = kwargs.get(
+            "diff_output_preservation_multiplier", 1.0
+        )
         # If the trigger word is in the prompt, we will use this class name to replace it eg. "sks woman" -> "woman"
-        self.diff_output_preservation_class = kwargs.get('diff_output_preservation_class', '')
+        self.diff_output_preservation_class = kwargs.get(
+            "diff_output_preservation_class", ""
+        )
 
         # legacy
         if match_adapter_assist and self.match_adapter_chance == 0.0:
             self.match_adapter_chance = 1.0
 
         # standardize inputs to the meand std of the model knowledge
-        self.standardize_images = kwargs.get('standardize_images', False)
-        self.standardize_latents = kwargs.get('standardize_latents', False)
+        self.standardize_images = kwargs.get("standardize_images", False)
+        self.standardize_latents = kwargs.get("standardize_latents", False)
 
         # if self.train_turbo and not self.noise_scheduler.startswith("euler"):
         #     raise ValueError(f"train_turbo is only supported with euler and wuler_a noise schedulers")
 
-        self.dynamic_noise_offset = kwargs.get('dynamic_noise_offset', False)
-        self.do_cfg = kwargs.get('do_cfg', False)
-        self.do_random_cfg = kwargs.get('do_random_cfg', False)
-        self.cfg_scale = kwargs.get('cfg_scale', 1.0)
-        self.max_cfg_scale = kwargs.get('max_cfg_scale', self.cfg_scale)
-        self.cfg_rescale = kwargs.get('cfg_rescale', None)
+        self.dynamic_noise_offset = kwargs.get("dynamic_noise_offset", False)
+        self.do_cfg = kwargs.get("do_cfg", False)
+        self.do_random_cfg = kwargs.get("do_random_cfg", False)
+        self.cfg_scale = kwargs.get("cfg_scale", 1.0)
+        self.max_cfg_scale = kwargs.get("max_cfg_scale", self.cfg_scale)
+        self.cfg_rescale = kwargs.get("cfg_rescale", None)
         if self.cfg_rescale is None:
             self.cfg_rescale = self.cfg_scale
 
         # applies the inverse of the prediction mean and std to the target to correct
         # for norm drift
-        self.correct_pred_norm = kwargs.get('correct_pred_norm', False)
-        self.correct_pred_norm_multiplier = kwargs.get('correct_pred_norm_multiplier', 1.0)
+        self.correct_pred_norm = kwargs.get("correct_pred_norm", False)
+        self.correct_pred_norm_multiplier = kwargs.get(
+            "correct_pred_norm_multiplier", 1.0
+        )
 
-        self.loss_type = kwargs.get('loss_type', 'mse') # mse, mae, wavelet, pixelspace, cfm, mean_flow
+        self.loss_type = kwargs.get(
+            "loss_type", "mse"
+        )  # mse, mae, wavelet, pixelspace, cfm, mean_flow
 
         # scale the prediction by this. Increase for more detail, decrease for less
-        self.pred_scaler = kwargs.get('pred_scaler', 1.0)
+        self.pred_scaler = kwargs.get("pred_scaler", 1.0)
 
         # repeats the prompt a few times to saturate the encoder
-        self.prompt_saturation_chance = kwargs.get('prompt_saturation_chance', 0.0)
+        self.prompt_saturation_chance = kwargs.get("prompt_saturation_chance", 0.0)
 
         # applies negative loss on the prior to encourage network to diverge from it
-        self.do_prior_divergence = kwargs.get('do_prior_divergence', False)
+        self.do_prior_divergence = kwargs.get("do_prior_divergence", False)
 
-        ema_config: Union[Dict, None] = kwargs.get('ema_config', None)
-        # if it is set explicitly to false, leave it false. 
-        if ema_config is not None and ema_config.get('use_ema', None) is not None:
-            ema_config['use_ema'] = True
+        ema_config: Union[Dict, None] = kwargs.get("ema_config", None)
+        # if it is set explicitly to false, leave it false.
+        if ema_config is not None and ema_config.get("use_ema", None) is not None:
+            ema_config["use_ema"] = True
             print(f"Using EMA")
         else:
-            ema_config = {'use_ema': False}
+            ema_config = {"use_ema": False}
 
         self.ema_config: EMAConfig = EMAConfig(**ema_config)
 
         # adds an additional loss to the network to encourage it output a normalized standard deviation
-        self.target_norm_std = kwargs.get('target_norm_std', None)
-        self.target_norm_std_value = kwargs.get('target_norm_std_value', 1.0)
-        self.timestep_type = kwargs.get('timestep_type', 'sigmoid')  # sigmoid, linear, lognorm_blend, next_sample, weighted, one_step
-        self.next_sample_timesteps = kwargs.get('next_sample_timesteps', 8)
-        self.linear_timesteps = kwargs.get('linear_timesteps', False)
-        self.linear_timesteps2 = kwargs.get('linear_timesteps2', False)
-        self.disable_sampling = kwargs.get('disable_sampling', False)
+        self.target_norm_std = kwargs.get("target_norm_std", None)
+        self.target_norm_std_value = kwargs.get("target_norm_std_value", 1.0)
+        self.timestep_type = kwargs.get(
+            "timestep_type", "sigmoid"
+        )  # sigmoid, linear, lognorm_blend, next_sample, weighted, one_step
+        self.next_sample_timesteps = kwargs.get("next_sample_timesteps", 8)
+        self.linear_timesteps = kwargs.get("linear_timesteps", False)
+        self.linear_timesteps2 = kwargs.get("linear_timesteps2", False)
+        self.disable_sampling = kwargs.get("disable_sampling", False)
 
         # will cache a blank prompt or the trigger word, and unload the text encoder to cpu
         # will make training faster and use less vram
-        self.unload_text_encoder = kwargs.get('unload_text_encoder', False)
+        self.unload_text_encoder = kwargs.get("unload_text_encoder", False)
         # for swapping which parameters are trained during training
-        self.do_paramiter_swapping = kwargs.get('do_paramiter_swapping', False)
+        self.do_paramiter_swapping = kwargs.get("do_paramiter_swapping", False)
         # 0.1 is 10% of the parameters active at a time lower is less vram, higher is more
-        self.paramiter_swapping_factor = kwargs.get('paramiter_swapping_factor', 0.1)
+        self.paramiter_swapping_factor = kwargs.get("paramiter_swapping_factor", 0.1)
         # bypass the guidance embedding for training. For open flux with guidance embedding
-        self.bypass_guidance_embedding = kwargs.get('bypass_guidance_embedding', False)
-        
+        self.bypass_guidance_embedding = kwargs.get("bypass_guidance_embedding", False)
+
         # diffusion feature extractor
-        self.diffusion_feature_extractor_path = kwargs.get('diffusion_feature_extractor_path', None)
-        self.diffusion_feature_extractor_weight = kwargs.get('diffusion_feature_extractor_weight', 1.0)
-        
+        self.diffusion_feature_extractor_path = kwargs.get(
+            "diffusion_feature_extractor_path", None
+        )
+        self.diffusion_feature_extractor_weight = kwargs.get(
+            "diffusion_feature_extractor_weight", 1.0
+        )
+
         # optimal noise pairing
-        self.optimal_noise_pairing_samples = kwargs.get('optimal_noise_pairing_samples', 1)
-        
+        self.optimal_noise_pairing_samples = kwargs.get(
+            "optimal_noise_pairing_samples", 1
+        )
+
+        # validation
+        self.validation_every = kwargs.get(
+            "validation_every", 1000
+        )  # Set to same as save_every by default
+
         # forces same noise for the same image at a given size.
-        self.force_consistent_noise = kwargs.get('force_consistent_noise', False)
-        self.blended_blur_noise = kwargs.get('blended_blur_noise', False)
+        self.force_consistent_noise = kwargs.get("force_consistent_noise", False)
+        self.blended_blur_noise = kwargs.get("blended_blur_noise", False)
 
 
-ModelArch = Literal['sd1', 'sd2', 'sd3', 'sdxl', 'pixart', 'pixart_sigma', 'auraflow', 'flux', 'flex1', 'flex2', 'lumina2', 'vega', 'ssd', 'wan21']
+ModelArch = Literal[
+    "sd1",
+    "sd2",
+    "sd3",
+    "sdxl",
+    "pixart",
+    "pixart_sigma",
+    "auraflow",
+    "flux",
+    "flex1",
+    "flex2",
+    "lumina2",
+    "vega",
+    "ssd",
+    "wan21",
+]
 
 
 class ModelConfig:
     def __init__(self, **kwargs):
-        self.name_or_path: str = kwargs.get('name_or_path', None)
+        self.name_or_path: str = kwargs.get("name_or_path", None)
         # name or path is updated on fine tuning. Keep a copy of the original
         self.name_or_path_original: str = self.name_or_path
-        self.is_v2: bool = kwargs.get('is_v2', False)
-        self.is_xl: bool = kwargs.get('is_xl', False)
-        self.is_pixart: bool = kwargs.get('is_pixart', False)
-        self.is_pixart_sigma: bool = kwargs.get('is_pixart_sigma', False)
-        self.is_auraflow: bool = kwargs.get('is_auraflow', False)
-        self.is_v3: bool = kwargs.get('is_v3', False)
-        self.is_flux: bool = kwargs.get('is_flux', False)
-        self.is_lumina2: bool = kwargs.get('is_lumina2', False)
+        self.is_v2: bool = kwargs.get("is_v2", False)
+        self.is_xl: bool = kwargs.get("is_xl", False)
+        self.is_pixart: bool = kwargs.get("is_pixart", False)
+        self.is_pixart_sigma: bool = kwargs.get("is_pixart_sigma", False)
+        self.is_auraflow: bool = kwargs.get("is_auraflow", False)
+        self.is_v3: bool = kwargs.get("is_v3", False)
+        self.is_flux: bool = kwargs.get("is_flux", False)
+        self.is_lumina2: bool = kwargs.get("is_lumina2", False)
         if self.is_pixart_sigma:
             self.is_pixart = True
-        self.use_flux_cfg = kwargs.get('use_flux_cfg', False)
-        self.is_ssd: bool = kwargs.get('is_ssd', False)
-        self.is_vega: bool = kwargs.get('is_vega', False)
-        self.is_v_pred: bool = kwargs.get('is_v_pred', False)
-        self.dtype: str = kwargs.get('dtype', 'float16')
-        self.vae_path = kwargs.get('vae_path', None)
-        self.refiner_name_or_path = kwargs.get('refiner_name_or_path', None)
+        self.use_flux_cfg = kwargs.get("use_flux_cfg", False)
+        self.is_ssd: bool = kwargs.get("is_ssd", False)
+        self.is_vega: bool = kwargs.get("is_vega", False)
+        self.is_v_pred: bool = kwargs.get("is_v_pred", False)
+        self.dtype: str = kwargs.get("dtype", "float16")
+        self.vae_path = kwargs.get("vae_path", None)
+        self.refiner_name_or_path = kwargs.get("refiner_name_or_path", None)
         self._original_refiner_name_or_path = self.refiner_name_or_path
-        self.refiner_start_at = kwargs.get('refiner_start_at', 0.5)
-        self.lora_path = kwargs.get('lora_path', None)
+        self.refiner_start_at = kwargs.get("refiner_start_at", 0.5)
+        self.lora_path = kwargs.get("lora_path", None)
         # mainly for decompression loras for distilled models
-        self.assistant_lora_path = kwargs.get('assistant_lora_path', None)
-        self.inference_lora_path = kwargs.get('inference_lora_path', None)
-        self.latent_space_version = kwargs.get('latent_space_version', None)
+        self.assistant_lora_path = kwargs.get("assistant_lora_path", None)
+        self.inference_lora_path = kwargs.get("inference_lora_path", None)
+        self.latent_space_version = kwargs.get("latent_space_version", None)
 
         # only for SDXL models for now
-        self.use_text_encoder_1: bool = kwargs.get('use_text_encoder_1', True)
-        self.use_text_encoder_2: bool = kwargs.get('use_text_encoder_2', True)
+        self.use_text_encoder_1: bool = kwargs.get("use_text_encoder_1", True)
+        self.use_text_encoder_2: bool = kwargs.get("use_text_encoder_2", True)
 
-        self.experimental_xl: bool = kwargs.get('experimental_xl', False)
+        self.experimental_xl: bool = kwargs.get("experimental_xl", False)
 
         if self.name_or_path is None:
-            raise ValueError('name_or_path must be specified')
+            raise ValueError("name_or_path must be specified")
 
         if self.is_ssd:
             # sed sdxl as true since it is mostly the same architecture
@@ -515,7 +606,7 @@ class ModelConfig:
             self.is_xl = True
 
         # for text encoder quant. Only works with pixart currently
-        self.text_encoder_bits = kwargs.get('text_encoder_bits', 16)  # 16, 8, 4
+        self.text_encoder_bits = kwargs.get("text_encoder_bits", 16)  # 16, 8, 4
         self.unet_path = kwargs.get("unet_path", None)
         self.unet_sample_size = kwargs.get("unet_sample_size", None)
         self.vae_device = kwargs.get("vae_device", None)
@@ -531,175 +622,189 @@ class ModelConfig:
         self.low_vram = kwargs.get("low_vram", False)
         self.attn_masking = kwargs.get("attn_masking", False)
         if self.attn_masking and not self.is_flux:
-            raise ValueError("attn_masking is only supported with flux models currently")
+            raise ValueError(
+                "attn_masking is only supported with flux models currently"
+            )
         # for targeting a specific layers
-        self.ignore_if_contains: Optional[List[str]] = kwargs.get("ignore_if_contains", None)
-        self.only_if_contains: Optional[List[str]] = kwargs.get("only_if_contains", None)
+        self.ignore_if_contains: Optional[List[str]] = kwargs.get(
+            "ignore_if_contains", None
+        )
+        self.only_if_contains: Optional[List[str]] = kwargs.get(
+            "only_if_contains", None
+        )
         self.quantize_kwargs = kwargs.get("quantize_kwargs", {})
-        
+
         # splits the model over the available gpus WIP
         self.split_model_over_gpus = kwargs.get("split_model_over_gpus", False)
         if self.split_model_over_gpus and not self.is_flux:
-            raise ValueError("split_model_over_gpus is only supported with flux models currently")
-        self.split_model_other_module_param_count_scale = kwargs.get("split_model_other_module_param_count_scale", 0.3)
-        
+            raise ValueError(
+                "split_model_over_gpus is only supported with flux models currently"
+            )
+        self.split_model_other_module_param_count_scale = kwargs.get(
+            "split_model_other_module_param_count_scale", 0.3
+        )
+
         self.te_name_or_path = kwargs.get("te_name_or_path", None)
-        
+
         self.arch: ModelArch = kwargs.get("arch", None)
-        
+
         # can be used to load the extras like text encoder or vae from here
         # only setup for some models but will prevent having to download the te for
         # 20 different model variants
         self.extras_name_or_path = kwargs.get("extras_name_or_path", self.name_or_path)
-        
+
         # kwargs to pass to the model
         self.model_kwargs = kwargs.get("model_kwargs", {})
-        
+
         # allow frontend to pass arch with a color like arch:tag
         # but remove the tag
         if self.arch is not None:
-            if ':' in self.arch:
-                self.arch = self.arch.split(':')[0]
-        
+            if ":" in self.arch:
+                self.arch = self.arch.split(":")[0]
+
         if self.arch == "flex1":
             self.arch = "flux"
-        
+
         # handle migrating to new model arch
         if self.arch is not None:
             # reverse the arch to the old style
-            if self.arch == 'sd2':
+            if self.arch == "sd2":
                 self.is_v2 = True
-            elif self.arch == 'sd3':
+            elif self.arch == "sd3":
                 self.is_v3 = True
-            elif self.arch == 'sdxl':
+            elif self.arch == "sdxl":
                 self.is_xl = True
-            elif self.arch == 'pixart':
+            elif self.arch == "pixart":
                 self.is_pixart = True
-            elif self.arch == 'pixart_sigma':
+            elif self.arch == "pixart_sigma":
                 self.is_pixart_sigma = True
-            elif self.arch == 'auraflow':
+            elif self.arch == "auraflow":
                 self.is_auraflow = True
-            elif self.arch == 'flux':
+            elif self.arch == "flux":
                 self.is_flux = True
-            elif self.arch == 'lumina2':
+            elif self.arch == "lumina2":
                 self.is_lumina2 = True
-            elif self.arch == 'vega':
+            elif self.arch == "vega":
                 self.is_vega = True
-            elif self.arch == 'ssd':
+            elif self.arch == "ssd":
                 self.is_ssd = True
             else:
                 pass
         if self.arch is None:
-            if kwargs.get('is_v2', False):
-                self.arch = 'sd2'
-            elif kwargs.get('is_v3', False):
-                self.arch = 'sd3'
-            elif kwargs.get('is_xl', False):
-                self.arch = 'sdxl'
-            elif kwargs.get('is_pixart', False):
-                self.arch = 'pixart'
-            elif kwargs.get('is_pixart_sigma', False):
-                self.arch = 'pixart_sigma'
-            elif kwargs.get('is_auraflow', False):
-                self.arch = 'auraflow'
-            elif kwargs.get('is_flux', False):
-                self.arch = 'flux'
-            elif kwargs.get('is_lumina2', False):
-                self.arch = 'lumina2'
-            elif kwargs.get('is_vega', False):
-                self.arch = 'vega'
-            elif kwargs.get('is_ssd', False):
-                self.arch = 'ssd'
+            if kwargs.get("is_v2", False):
+                self.arch = "sd2"
+            elif kwargs.get("is_v3", False):
+                self.arch = "sd3"
+            elif kwargs.get("is_xl", False):
+                self.arch = "sdxl"
+            elif kwargs.get("is_pixart", False):
+                self.arch = "pixart"
+            elif kwargs.get("is_pixart_sigma", False):
+                self.arch = "pixart_sigma"
+            elif kwargs.get("is_auraflow", False):
+                self.arch = "auraflow"
+            elif kwargs.get("is_flux", False):
+                self.arch = "flux"
+            elif kwargs.get("is_lumina2", False):
+                self.arch = "lumina2"
+            elif kwargs.get("is_vega", False):
+                self.arch = "vega"
+            elif kwargs.get("is_ssd", False):
+                self.arch = "ssd"
             else:
-                self.arch = 'sd1'
-        
+                self.arch = "sd1"
 
 
 class EMAConfig:
     def __init__(self, **kwargs):
-        self.use_ema: bool = kwargs.get('use_ema', False)
-        self.ema_decay: float = kwargs.get('ema_decay', 0.999)
+        self.use_ema: bool = kwargs.get("use_ema", False)
+        self.ema_decay: float = kwargs.get("ema_decay", 0.999)
         # feeds back the decay difference into the parameter
-        self.use_feedback: bool = kwargs.get('use_feedback', False)
-        
+        self.use_feedback: bool = kwargs.get("use_feedback", False)
+
         # every update, the params are multiplied by this amount
         # only use for things without a bias like lora
         # similar to a decay in an optimizer but the opposite
-        self.param_multiplier: float = kwargs.get('param_multiplier', 1.0)
+        self.param_multiplier: float = kwargs.get("param_multiplier", 1.0)
 
 
 class ReferenceDatasetConfig:
     def __init__(self, **kwargs):
         # can pass with a side by side pait or a folder with pos and neg folder
-        self.pair_folder: str = kwargs.get('pair_folder', None)
-        self.pos_folder: str = kwargs.get('pos_folder', None)
-        self.neg_folder: str = kwargs.get('neg_folder', None)
+        self.pair_folder: str = kwargs.get("pair_folder", None)
+        self.pos_folder: str = kwargs.get("pos_folder", None)
+        self.neg_folder: str = kwargs.get("neg_folder", None)
 
-        self.network_weight: float = float(kwargs.get('network_weight', 1.0))
-        self.pos_weight: float = float(kwargs.get('pos_weight', self.network_weight))
-        self.neg_weight: float = float(kwargs.get('neg_weight', self.network_weight))
+        self.network_weight: float = float(kwargs.get("network_weight", 1.0))
+        self.pos_weight: float = float(kwargs.get("pos_weight", self.network_weight))
+        self.neg_weight: float = float(kwargs.get("neg_weight", self.network_weight))
         # make sure they are all absolute values no negatives
         self.pos_weight = abs(self.pos_weight)
         self.neg_weight = abs(self.neg_weight)
 
-        self.target_class: str = kwargs.get('target_class', '')
-        self.size: int = kwargs.get('size', 512)
+        self.target_class: str = kwargs.get("target_class", "")
+        self.size: int = kwargs.get("size", 512)
 
 
 class SliderTargetConfig:
     def __init__(self, **kwargs):
-        self.target_class: str = kwargs.get('target_class', '')
-        self.positive: str = kwargs.get('positive', '')
-        self.negative: str = kwargs.get('negative', '')
-        self.multiplier: float = kwargs.get('multiplier', 1.0)
-        self.weight: float = kwargs.get('weight', 1.0)
-        self.shuffle: bool = kwargs.get('shuffle', False)
+        self.target_class: str = kwargs.get("target_class", "")
+        self.positive: str = kwargs.get("positive", "")
+        self.negative: str = kwargs.get("negative", "")
+        self.multiplier: float = kwargs.get("multiplier", 1.0)
+        self.weight: float = kwargs.get("weight", 1.0)
+        self.shuffle: bool = kwargs.get("shuffle", False)
 
 
 class GuidanceConfig:
     def __init__(self, **kwargs):
-        self.target_class: str = kwargs.get('target_class', '')
-        self.guidance_scale: float = kwargs.get('guidance_scale', 1.0)
-        self.positive_prompt: str = kwargs.get('positive_prompt', '')
-        self.negative_prompt: str = kwargs.get('negative_prompt', '')
+        self.target_class: str = kwargs.get("target_class", "")
+        self.guidance_scale: float = kwargs.get("guidance_scale", 1.0)
+        self.positive_prompt: str = kwargs.get("positive_prompt", "")
+        self.negative_prompt: str = kwargs.get("negative_prompt", "")
 
 
 class SliderConfigAnchors:
     def __init__(self, **kwargs):
-        self.prompt = kwargs.get('prompt', '')
-        self.neg_prompt = kwargs.get('neg_prompt', '')
-        self.multiplier = kwargs.get('multiplier', 1.0)
+        self.prompt = kwargs.get("prompt", "")
+        self.neg_prompt = kwargs.get("neg_prompt", "")
+        self.multiplier = kwargs.get("multiplier", 1.0)
 
 
 class SliderConfig:
     def __init__(self, **kwargs):
-        targets = kwargs.get('targets', [])
-        anchors = kwargs.get('anchors', [])
+        targets = kwargs.get("targets", [])
+        anchors = kwargs.get("anchors", [])
         anchors = [SliderConfigAnchors(**anchor) for anchor in anchors]
         self.anchors: List[SliderConfigAnchors] = anchors
-        self.resolutions: List[List[int]] = kwargs.get('resolutions', [[512, 512]])
-        self.prompt_file: str = kwargs.get('prompt_file', None)
-        self.prompt_tensors: str = kwargs.get('prompt_tensors', None)
-        self.batch_full_slide: bool = kwargs.get('batch_full_slide', True)
-        self.use_adapter: bool = kwargs.get('use_adapter', None)  # depth
-        self.adapter_img_dir = kwargs.get('adapter_img_dir', None)
-        self.low_ram = kwargs.get('low_ram', False)
+        self.resolutions: List[List[int]] = kwargs.get("resolutions", [[512, 512]])
+        self.prompt_file: str = kwargs.get("prompt_file", None)
+        self.prompt_tensors: str = kwargs.get("prompt_tensors", None)
+        self.batch_full_slide: bool = kwargs.get("batch_full_slide", True)
+        self.use_adapter: bool = kwargs.get("use_adapter", None)  # depth
+        self.adapter_img_dir = kwargs.get("adapter_img_dir", None)
+        self.low_ram = kwargs.get("low_ram", False)
 
         # expand targets if shuffling
         from toolkit.prompt_utils import get_slider_target_permutations
+
         self.targets: List[SliderTargetConfig] = []
         targets = [SliderTargetConfig(**target) for target in targets]
         # do permutations if shuffle is true
         print(f"Building slider targets")
         for target in targets:
             if target.shuffle:
-                target_permutations = get_slider_target_permutations(target, max_permutations=8)
+                target_permutations = get_slider_target_permutations(
+                    target, max_permutations=8
+                )
                 self.targets = self.targets + target_permutations
             else:
                 self.targets.append(target)
         print(f"Built {len(self.targets)} slider targets (with permutations)")
 
-ControlTypes = Literal['depth', 'line', 'pose', 'inpaint', 'mask']
+
+ControlTypes = Literal["depth", "line", "pose", "inpaint", "mask"]
+
 
 class DatasetConfig:
     """
@@ -708,125 +813,164 @@ class DatasetConfig:
     """
 
     def __init__(self, **kwargs):
-        self.type = kwargs.get('type', 'image')  # sd, slider, reference
+        self.type = kwargs.get("type", "image")  # sd, slider, reference
         # will be legacy
-        self.folder_path: str = kwargs.get('folder_path', None)
+        self.folder_path: str = kwargs.get("folder_path", None)
         # can be json or folder path
-        self.dataset_path: str = kwargs.get('dataset_path', None)
+        self.dataset_path: str = kwargs.get("dataset_path", None)
 
-        self.default_caption: str = kwargs.get('default_caption', None)
+        self.default_caption: str = kwargs.get("default_caption", None)
         # trigger word for just this dataset
-        self.trigger_word: str = kwargs.get('trigger_word', None)
-        random_triggers = kwargs.get('random_triggers', [])
+        self.trigger_word: str = kwargs.get("trigger_word", None)
+        random_triggers = kwargs.get("random_triggers", [])
         # if they are a string, load them from a file
         if isinstance(random_triggers, str) and os.path.exists(random_triggers):
-            with open(random_triggers, 'r') as f:
+            with open(random_triggers, "r") as f:
                 random_triggers = f.read().splitlines()
                 # remove empty lines
-                random_triggers = [line for line in random_triggers if line.strip() != '']
+                random_triggers = [
+                    line for line in random_triggers if line.strip() != ""
+                ]
         self.random_triggers: List[str] = random_triggers
-        self.random_triggers_max: int = kwargs.get('random_triggers_max', 1)
-        self.caption_ext: str = kwargs.get('caption_ext', '.txt')
+        self.random_triggers_max: int = kwargs.get("random_triggers_max", 1)
+        self.caption_ext: str = kwargs.get("caption_ext", ".txt")
         # if caption_ext doesnt start with a dot, add it
-        if self.caption_ext and not self.caption_ext.startswith('.'):
-            self.caption_ext = '.' + self.caption_ext
-        self.random_scale: bool = kwargs.get('random_scale', False)
-        self.random_crop: bool = kwargs.get('random_crop', False)
-        self.resolution: int = kwargs.get('resolution', 512)
-        self.scale: float = kwargs.get('scale', 1.0)
-        self.buckets: bool = kwargs.get('buckets', True)
-        self.bucket_tolerance: int = kwargs.get('bucket_tolerance', 64)
-        self.is_reg: bool = kwargs.get('is_reg', False)
-        self.network_weight: float = float(kwargs.get('network_weight', 1.0))
-        self.token_dropout_rate: float = float(kwargs.get('token_dropout_rate', 0.0))
-        self.shuffle_tokens: bool = kwargs.get('shuffle_tokens', False)
-        self.caption_dropout_rate: float = float(kwargs.get('caption_dropout_rate', 0.0))
-        self.keep_tokens: int = kwargs.get('keep_tokens', 0)  # #of first tokens to always keep unless caption dropped
-        self.flip_x: bool = kwargs.get('flip_x', False)
-        self.flip_y: bool = kwargs.get('flip_y', False)
-        self.augments: List[str] = kwargs.get('augments', [])
-        self.control_path: Union[str,List[str]] = kwargs.get('control_path', None)  # depth maps, etc
+        if self.caption_ext and not self.caption_ext.startswith("."):
+            self.caption_ext = "." + self.caption_ext
+        self.random_scale: bool = kwargs.get("random_scale", False)
+        self.random_crop: bool = kwargs.get("random_crop", False)
+        self.resolution: int = kwargs.get("resolution", 512)
+        self.scale: float = kwargs.get("scale", 1.0)
+        self.buckets: bool = kwargs.get("buckets", True)
+        self.bucket_tolerance: int = kwargs.get("bucket_tolerance", 64)
+        self.is_reg: bool = kwargs.get("is_reg", False)
+        self.network_weight: float = float(kwargs.get("network_weight", 1.0))
+        self.token_dropout_rate: float = float(kwargs.get("token_dropout_rate", 0.0))
+        self.shuffle_tokens: bool = kwargs.get("shuffle_tokens", False)
+        self.caption_dropout_rate: float = float(
+            kwargs.get("caption_dropout_rate", 0.0)
+        )
+        self.keep_tokens: int = kwargs.get(
+            "keep_tokens", 0
+        )  # #of first tokens to always keep unless caption dropped
+        self.flip_x: bool = kwargs.get("flip_x", False)
+        self.flip_y: bool = kwargs.get("flip_y", False)
+        self.augments: List[str] = kwargs.get("augments", [])
+        self.control_path: Union[str, List[str]] = kwargs.get(
+            "control_path", None
+        )  # depth maps, etc
         # inpaint images should be webp/png images with alpha channel. The alpha 0 (invisible) section will
         # be the part conditioned to be inpainted. The alpha 1 (visible) section will be the part that is ignored
-        self.inpaint_path: Union[str,List[str]] = kwargs.get('inpaint_path', None)
+        self.inpaint_path: Union[str, List[str]] = kwargs.get("inpaint_path", None)
         # instead of cropping ot match image, it will serve the full size control image (clip images ie for ip adapters)
-        self.full_size_control_images: bool = kwargs.get('full_size_control_images', False)
-        self.alpha_mask: bool = kwargs.get('alpha_mask', False)  # if true, will use alpha channel as mask
-        self.mask_path: str = kwargs.get('mask_path',
-                                         None)  # focus mask (black and white. White has higher loss than black)
-        self.unconditional_path: str = kwargs.get('unconditional_path',
-                                                  None)  # path where matching unconditional images are located
-        self.invert_mask: bool = kwargs.get('invert_mask', False)  # invert mask
-        self.mask_min_value: float = kwargs.get('mask_min_value', 0.0)  # min value for . 0 - 1
-        self.poi: Union[str, None] = kwargs.get('poi',
-                                                None)  # if one is set and in json data, will be used as auto crop scale point of interes
-        self.use_short_captions: bool = kwargs.get('use_short_captions', False)  # if true, will use 'caption_short' from json
-        self.num_repeats: int = kwargs.get('num_repeats', 1)  # number of times to repeat dataset
+        self.full_size_control_images: bool = kwargs.get(
+            "full_size_control_images", False
+        )
+        self.alpha_mask: bool = kwargs.get(
+            "alpha_mask", False
+        )  # if true, will use alpha channel as mask
+        self.mask_path: str = kwargs.get(
+            "mask_path", None
+        )  # focus mask (black and white. White has higher loss than black)
+        self.unconditional_path: str = kwargs.get(
+            "unconditional_path", None
+        )  # path where matching unconditional images are located
+        self.invert_mask: bool = kwargs.get("invert_mask", False)  # invert mask
+        self.mask_min_value: float = kwargs.get(
+            "mask_min_value", 0.0
+        )  # min value for . 0 - 1
+        self.poi: Union[str, None] = kwargs.get(
+            "poi", None
+        )  # if one is set and in json data, will be used as auto crop scale point of interes
+        self.use_short_captions: bool = kwargs.get(
+            "use_short_captions", False
+        )  # if true, will use 'caption_short' from json
+        self.num_repeats: int = kwargs.get(
+            "num_repeats", 1
+        )  # number of times to repeat dataset
         # cache latents will store them in memory
-        self.cache_latents: bool = kwargs.get('cache_latents', False)
+        self.cache_latents: bool = kwargs.get("cache_latents", False)
         # cache latents to disk will store them on disk. If both are true, it will save to disk, but keep in memory
-        self.cache_latents_to_disk: bool = kwargs.get('cache_latents_to_disk', False)
-        self.cache_clip_vision_to_disk: bool = kwargs.get('cache_clip_vision_to_disk', False)
+        self.cache_latents_to_disk: bool = kwargs.get("cache_latents_to_disk", False)
+        self.cache_clip_vision_to_disk: bool = kwargs.get(
+            "cache_clip_vision_to_disk", False
+        )
 
-        self.standardize_images: bool = kwargs.get('standardize_images', False)
+        self.standardize_images: bool = kwargs.get("standardize_images", False)
 
         # https://albumentations.ai/docs/api_reference/augmentations/transforms
         # augmentations are returned as a separate image and cannot currently be cached
-        self.augmentations: List[dict] = kwargs.get('augmentations', None)
-        self.shuffle_augmentations: bool = kwargs.get('shuffle_augmentations', False)
+        self.augmentations: List[dict] = kwargs.get("augmentations", None)
+        self.shuffle_augmentations: bool = kwargs.get("shuffle_augmentations", False)
 
-        has_augmentations = self.augmentations is not None and len(self.augmentations) > 0
+        has_augmentations = (
+            self.augmentations is not None and len(self.augmentations) > 0
+        )
 
-        if (len(self.augments) > 0 or has_augmentations) and (self.cache_latents or self.cache_latents_to_disk):
-            print(f"WARNING: Augments are not supported with caching latents. Setting cache_latents to False")
+        if (len(self.augments) > 0 or has_augmentations) and (
+            self.cache_latents or self.cache_latents_to_disk
+        ):
+            print(
+                f"WARNING: Augments are not supported with caching latents. Setting cache_latents to False"
+            )
             self.cache_latents = False
             self.cache_latents_to_disk = False
 
         # legacy compatability
-        legacy_caption_type = kwargs.get('caption_type', None)
+        legacy_caption_type = kwargs.get("caption_type", None)
         if legacy_caption_type:
             self.caption_ext = legacy_caption_type
         self.caption_type = self.caption_ext
-        self.guidance_type: GuidanceType = kwargs.get('guidance_type', 'targeted')
+        self.guidance_type: GuidanceType = kwargs.get("guidance_type", "targeted")
 
         # ip adapter / reference dataset
-        self.clip_image_path: str = kwargs.get('clip_image_path', None)  # depth maps, etc
+        self.clip_image_path: str = kwargs.get(
+            "clip_image_path", None
+        )  # depth maps, etc
         # get the clip image randomly from the same folder as the image. Useful for folder grouped pairs.
-        self.clip_image_from_same_folder: bool = kwargs.get('clip_image_from_same_folder', False)
-        self.clip_image_augmentations: List[dict] = kwargs.get('clip_image_augmentations', None)
-        self.clip_image_shuffle_augmentations: bool = kwargs.get('clip_image_shuffle_augmentations', False)
-        self.replacements: List[str] = kwargs.get('replacements', [])
-        self.loss_multiplier: float = kwargs.get('loss_multiplier', 1.0)
+        self.clip_image_from_same_folder: bool = kwargs.get(
+            "clip_image_from_same_folder", False
+        )
+        self.clip_image_augmentations: List[dict] = kwargs.get(
+            "clip_image_augmentations", None
+        )
+        self.clip_image_shuffle_augmentations: bool = kwargs.get(
+            "clip_image_shuffle_augmentations", False
+        )
+        self.replacements: List[str] = kwargs.get("replacements", [])
+        self.loss_multiplier: float = kwargs.get("loss_multiplier", 1.0)
 
-        self.num_workers: int = kwargs.get('num_workers', 2)
-        self.prefetch_factor: int = kwargs.get('prefetch_factor', 2)
-        self.extra_values: List[float] = kwargs.get('extra_values', [])
-        self.square_crop: bool = kwargs.get('square_crop', False)
+        self.num_workers: int = kwargs.get("num_workers", 2)
+        self.prefetch_factor: int = kwargs.get("prefetch_factor", 2)
+        self.extra_values: List[float] = kwargs.get("extra_values", [])
+        self.square_crop: bool = kwargs.get("square_crop", False)
         # apply same augmentations to control images. Usually want this true unless special case
-        self.replay_transforms: bool = kwargs.get('replay_transforms', True)
-        
+        self.replay_transforms: bool = kwargs.get("replay_transforms", True)
+        # validation
+        self.validation_percent = kwargs.get("validation_percent", 0.1)  # 10% holdout
+
         # for video
         # if num_frames is greater than 1, the dataloader will look for video files.
         # num_frames will be the number of frames in the training batch. If num_frames is 1, it will look for images
-        self.num_frames: int = kwargs.get('num_frames', 1)
+        self.num_frames: int = kwargs.get("num_frames", 1)
         # if true, will shrink video to our frames. For instance, if we have a video with 100 frames and num_frames is 10,
         # we would pull frame 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 so they are evenly spaced
-        self.shrink_video_to_frames: bool = kwargs.get('shrink_video_to_frames', True)
+        self.shrink_video_to_frames: bool = kwargs.get("shrink_video_to_frames", True)
         # fps is only used if shrink_video_to_frames is false. This will attempt to pull the num_frames at the given fps
         # it will select a random start frame and pull the frames at the given fps
         # this could have various issues with shorter videos and videos with variable fps
         # I recommend trimming your videos to the desired length and using shrink_video_to_frames(default)
-        self.fps: int = kwargs.get('fps', 16)
-        
+        self.fps: int = kwargs.get("fps", 16)
+
         # debug the frame count and frame selection. You dont need this. It is for debugging.
-        self.debug: bool = kwargs.get('debug', False)
-        
+        self.debug: bool = kwargs.get("debug", False)
+
         # automatic controls
-        self.controls: List[ControlTypes] = kwargs.get('controls', [])
+        self.controls: List[ControlTypes] = kwargs.get("controls", [])
         if isinstance(self.controls, str):
             self.controls = [self.controls]
         # remove empty strings
-        self.controls = [control for control in self.controls if control.strip() != '']
+        self.controls = [control for control in self.controls if control.strip() != ""]
 
 
 def preprocess_dataset_raw_config(raw_config: List[dict]) -> List[dict]:
@@ -838,48 +982,48 @@ def preprocess_dataset_raw_config(raw_config: List[dict]) -> List[dict]:
     # split up datasets by resolutions
     new_config = []
     for dataset in raw_config:
-        resolution = dataset.get('resolution', 512)
+        resolution = dataset.get("resolution", 512)
         if isinstance(resolution, list):
             resolution_list = resolution
         else:
             resolution_list = [resolution]
         for res in resolution_list:
             dataset_copy = dataset.copy()
-            dataset_copy['resolution'] = res
+            dataset_copy["resolution"] = res
             new_config.append(dataset_copy)
     return new_config
 
 
 class GenerateImageConfig:
     def __init__(
-            self,
-            prompt: str = '',
-            prompt_2: Optional[str] = None,
-            width: int = 512,
-            height: int = 512,
-            num_inference_steps: int = 50,
-            guidance_scale: float = 7.5,
-            negative_prompt: str = '',
-            negative_prompt_2: Optional[str] = None,
-            seed: int = -1,
-            network_multiplier: float = 1.0,
-            guidance_rescale: float = 0.0,
-            # the tag [time] will be replaced with milliseconds since epoch
-            output_path: str = None,  # full image path
-            output_folder: str = None,  # folder to save image in if output_path is not specified
-            output_ext: str = ImgExt,  # extension to save image as if output_path is not specified
-            output_tail: str = '',  # tail to add to output filename
-            add_prompt_file: bool = False,  # add a prompt file with generated image
-            adapter_image_path: str = None,  # path to adapter image
-            adapter_conditioning_scale: float = 1.0,  # scale for adapter conditioning
-            latents: Union[torch.Tensor | None] = None,  # input latent to start with,
-            extra_kwargs: dict = None,  # extra data to save with prompt file
-            refiner_start_at: float = 0.5,  # start at this percentage of a step. 0.0 to 1.0 . 1.0 is the end
-            extra_values: List[float] = None,  # extra values to save with prompt file
-            logger: Optional[EmptyLogger] = None,
-            num_frames: int = 1,
-            fps: int = 15,
-            ctrl_idx: int = 0
+        self,
+        prompt: str = "",
+        prompt_2: Optional[str] = None,
+        width: int = 512,
+        height: int = 512,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 7.5,
+        negative_prompt: str = "",
+        negative_prompt_2: Optional[str] = None,
+        seed: int = -1,
+        network_multiplier: float = 1.0,
+        guidance_rescale: float = 0.0,
+        # the tag [time] will be replaced with milliseconds since epoch
+        output_path: str = None,  # full image path
+        output_folder: str = None,  # folder to save image in if output_path is not specified
+        output_ext: str = ImgExt,  # extension to save image as if output_path is not specified
+        output_tail: str = "",  # tail to add to output filename
+        add_prompt_file: bool = False,  # add a prompt file with generated image
+        adapter_image_path: str = None,  # path to adapter image
+        adapter_conditioning_scale: float = 1.0,  # scale for adapter conditioning
+        latents: Union[torch.Tensor | None] = None,  # input latent to start with,
+        extra_kwargs: dict = None,  # extra data to save with prompt file
+        refiner_start_at: float = 0.5,  # start at this percentage of a step. 0.0 to 1.0 . 1.0 is the end
+        extra_values: List[float] = None,  # extra values to save with prompt file
+        logger: Optional[EmptyLogger] = None,
+        num_frames: int = 1,
+        fps: int = 15,
+        ctrl_idx: int = 0,
     ):
         self.width: int = width
         self.height: int = height
@@ -896,7 +1040,7 @@ class GenerateImageConfig:
         self.seed: int = seed
         if self.seed == -1:
             # generate random one
-            self.seed = random.randint(0, 2 ** 32 - 1)
+            self.seed = random.randint(0, 2**32 - 1)
         self.network_multiplier: float = network_multiplier
         self.output_folder: str = output_folder
         self.output_ext: str = output_ext
@@ -912,7 +1056,6 @@ class GenerateImageConfig:
         self.fps = fps
         self.ctrl_img = None
         self.ctrl_idx = ctrl_idx
-        
 
         # prompt string will override any settings above
         self._process_prompt_string()
@@ -926,17 +1069,21 @@ class GenerateImageConfig:
 
         # parse prompt paths
         if self.output_path is None and self.output_folder is None:
-            raise ValueError('output_path or output_folder must be specified')
+            raise ValueError("output_path or output_folder must be specified")
         elif self.output_path is not None:
             self.output_folder = os.path.dirname(self.output_path)
             self.output_ext = os.path.splitext(self.output_path)[1][1:]
-            self.output_filename_no_ext = os.path.splitext(os.path.basename(self.output_path))[0]
+            self.output_filename_no_ext = os.path.splitext(
+                os.path.basename(self.output_path)
+            )[0]
 
         else:
-            self.output_filename_no_ext = '[time]_[count]'
+            self.output_filename_no_ext = "[time]_[count]"
             if len(self.output_tail) > 0:
-                self.output_filename_no_ext += '_' + self.output_tail
-            self.output_path = os.path.join(self.output_folder, self.output_filename_no_ext + '.' + self.output_ext)
+                self.output_filename_no_ext += "_" + self.output_tail
+            self.output_path = os.path.join(
+                self.output_folder, self.output_filename_no_ext + "." + self.output_ext
+            )
 
         # adjust height
         self.height = max(64, self.height - self.height % 8)  # round to divisible by 8
@@ -954,24 +1101,24 @@ class GenerateImageConfig:
         # zero pad count
         count_str = str(count).zfill(len(str(max_count)))
         # replace [time] with gen time
-        filename = self.output_filename_no_ext.replace('[time]', str(self.gen_time))
+        filename = self.output_filename_no_ext.replace("[time]", str(self.gen_time))
         # replace [count] with count
-        filename = filename.replace('[count]', count_str)
+        filename = filename.replace("[count]", count_str)
         return filename
 
     def get_image_path(self, count: int = 0, max_count=0):
         filename = self._get_path_no_ext(count, max_count)
         ext = self.output_ext
         # if it does not start with a dot add one
-        if ext[0] != '.':
-            ext = '.' + ext
+        if ext[0] != ".":
+            ext = "." + ext
         filename += ext
         # join with folder
         return os.path.join(self.output_folder, filename)
 
     def get_prompt_path(self, count: int = 0, max_count=0):
         filename = self._get_path_no_ext(count, max_count)
-        filename += '.txt'
+        filename += ".txt"
         # join with folder
         return os.path.join(self.output_folder, filename)
 
@@ -983,19 +1130,19 @@ class GenerateImageConfig:
             # video
             if self.num_frames == 1:
                 raise ValueError(f"Expected 1 img but got a list {len(image)}")
-            if self.num_frames > 1 and self.output_ext not in ['webp']:
-                self.output_ext = 'webp'
-            if self.output_ext == 'webp':
+            if self.num_frames > 1 and self.output_ext not in ["webp"]:
+                self.output_ext = "webp"
+            if self.output_ext == "webp":
                 # save as animated webp
                 duration = 1000 // self.fps  # Convert fps to milliseconds per frame
                 image[0].save(
                     self.get_image_path(count, max_count),
-                    format='WEBP',
+                    format="WEBP",
                     append_images=image[1:],
                     save_all=True,
                     duration=duration,  # Duration per frame in milliseconds
                     loop=0,  # 0 means loop forever
-                    quality=80  # Quality setting (0-100)
+                    quality=80,  # Quality setting (0-100)
                 )
             else:
                 raise ValueError(f"Unsupported video format {self.output_ext}")
@@ -1008,27 +1155,29 @@ class GenerateImageConfig:
 
     def save_prompt_file(self, count: int = 0, max_count=0):
         # save prompt file
-        with open(self.get_prompt_path(count, max_count), 'w') as f:
+        with open(self.get_prompt_path(count, max_count), "w") as f:
             prompt = self.prompt
             if self.prompt_2 is not None:
-                prompt += ' --p2 ' + self.prompt_2
+                prompt += " --p2 " + self.prompt_2
             if self.negative_prompt is not None:
-                prompt += ' --n ' + self.negative_prompt
+                prompt += " --n " + self.negative_prompt
             if self.negative_prompt_2 is not None:
-                prompt += ' --n2 ' + self.negative_prompt_2
-            prompt += ' --w ' + str(self.width)
-            prompt += ' --h ' + str(self.height)
-            prompt += ' --seed ' + str(self.seed)
-            prompt += ' --cfg ' + str(self.guidance_scale)
-            prompt += ' --steps ' + str(self.num_inference_steps)
-            prompt += ' --m ' + str(self.network_multiplier)
-            prompt += ' --gr ' + str(self.guidance_rescale)
+                prompt += " --n2 " + self.negative_prompt_2
+            prompt += " --w " + str(self.width)
+            prompt += " --h " + str(self.height)
+            prompt += " --seed " + str(self.seed)
+            prompt += " --cfg " + str(self.guidance_scale)
+            prompt += " --steps " + str(self.num_inference_steps)
+            prompt += " --m " + str(self.network_multiplier)
+            prompt += " --gr " + str(self.guidance_rescale)
 
             # get gen info
             try:
                 f.write(self.prompt)
             except Exception as e:
-                print(f"Error writing prompt file. Prompt contains non-unicode characters. {e}")
+                print(
+                    f"Error writing prompt file. Prompt contains non-unicode characters. {e}"
+                )
 
     def _process_prompt_string(self):
         # we will try to support all sd-scripts where we can
@@ -1057,87 +1206,87 @@ class GenerateImageConfig:
             # process prompt string
             prompt = self.prompt
             prompt = prompt.strip()
-            p_split = prompt.split('--')
+            p_split = prompt.split("--")
             self.prompt = p_split[0].strip()
 
             if len(p_split) > 1:
                 for split in p_split[1:]:
                     # allows multi char flags
-                    flag = split.split(' ')[0].strip()
-                    content = split[len(flag):].strip()
-                    if flag == 'p2':
+                    flag = split.split(" ")[0].strip()
+                    content = split[len(flag) :].strip()
+                    if flag == "p2":
                         self.prompt_2 = content
-                    elif flag == 'n':
+                    elif flag == "n":
                         self.negative_prompt = content
-                    elif flag == 'n2':
+                    elif flag == "n2":
                         self.negative_prompt_2 = content
-                    elif flag == 'w':
+                    elif flag == "w":
                         self.width = int(content)
-                    elif flag == 'h':
+                    elif flag == "h":
                         self.height = int(content)
-                    elif flag == 'd':
+                    elif flag == "d":
                         self.seed = int(content)
-                    elif flag == 'seed':
+                    elif flag == "seed":
                         self.seed = int(content)
-                    elif flag == 'l':
+                    elif flag == "l":
                         self.guidance_scale = float(content)
-                    elif flag == 'cfg':
+                    elif flag == "cfg":
                         self.guidance_scale = float(content)
-                    elif flag == 's':
+                    elif flag == "s":
                         self.num_inference_steps = int(content)
-                    elif flag == 'steps':
+                    elif flag == "steps":
                         self.num_inference_steps = int(content)
-                    elif flag == 'm':
+                    elif flag == "m":
                         self.network_multiplier = float(content)
-                    elif flag == 'network_multiplier':
+                    elif flag == "network_multiplier":
                         self.network_multiplier = float(content)
-                    elif flag == 'gr':
+                    elif flag == "gr":
                         self.guidance_rescale = float(content)
-                    elif flag == 'a':
+                    elif flag == "a":
                         self.adapter_conditioning_scale = float(content)
-                    elif flag == 'ref':
+                    elif flag == "ref":
                         self.refiner_start_at = float(content)
-                    elif flag == 'ev':
+                    elif flag == "ev":
                         # split by comma
-                        self.extra_values = [float(val) for val in content.split(',')]
-                    elif flag == 'extra_values':
+                        self.extra_values = [float(val) for val in content.split(",")]
+                    elif flag == "extra_values":
                         # split by comma
-                        self.extra_values = [float(val) for val in content.split(',')]
-                    elif flag == 'frames':
+                        self.extra_values = [float(val) for val in content.split(",")]
+                    elif flag == "frames":
                         self.num_frames = int(content)
-                    elif flag == 'num_frames':
+                    elif flag == "num_frames":
                         self.num_frames = int(content)
-                    elif flag == 'fps':
+                    elif flag == "fps":
                         self.fps = int(content)
-                    elif flag == 'ctrl_img':
+                    elif flag == "ctrl_img":
                         self.ctrl_img = content
-                    elif flag == 'ctrl_idx':
+                    elif flag == "ctrl_idx":
                         self.ctrl_idx = int(content)
 
     def post_process_embeddings(
-            self,
-            conditional_prompt_embeds: PromptEmbeds,
-            unconditional_prompt_embeds: Optional[PromptEmbeds] = None,
+        self,
+        conditional_prompt_embeds: PromptEmbeds,
+        unconditional_prompt_embeds: Optional[PromptEmbeds] = None,
     ):
         # this is called after prompt embeds are encoded. We can override them in the future here
         pass
-    
+
     def log_image(self, image, count: int = 0, max_count=0):
         if self.logger is None:
             return
 
         self.logger.log_image(image, count, self.prompt)
-        
-        
+
+
 def validate_configs(
     train_config: TrainConfig,
     model_config: ModelConfig,
     save_config: SaveConfig,
 ):
     if model_config.is_flux:
-        if save_config.save_format != 'diffusers':
+        if save_config.save_format != "diffusers":
             # make it diffusers
-            save_config.save_format = 'diffusers'
+            save_config.save_format = "diffusers"
         if model_config.use_flux_cfg:
             # bypass the embedding
             train_config.bypass_guidance_embedding = True

--- a/toolkit/data_loader.py
+++ b/toolkit/data_loader.py
@@ -12,28 +12,37 @@ import torch
 from PIL import Image
 from PIL.ImageOps import exif_transpose
 from torchvision import transforms
-from torch.utils.data import Dataset, DataLoader, ConcatDataset
+from torch.utils.data import Dataset, DataLoader, ConcatDataset, random_split
 from tqdm import tqdm
 import albumentations as A
 
 from toolkit.buckets import get_bucket_for_image_size, BucketResolution
 from toolkit.config_modules import DatasetConfig, preprocess_dataset_raw_config
-from toolkit.dataloader_mixins import CaptionMixin, BucketsMixin, LatentCachingMixin, Augments, CLIPCachingMixin, ControlCachingMixin
+from toolkit.dataloader_mixins import (
+    CaptionMixin,
+    BucketsMixin,
+    LatentCachingMixin,
+    Augments,
+    CLIPCachingMixin,
+    ControlCachingMixin,
+)
 from toolkit.data_transfer_object.data_loader import FileItemDTO, DataLoaderBatchDTO
 from toolkit.print import print_acc
 from toolkit.accelerator import get_accelerator
 
 import platform
 
+
 def is_native_windows():
     return platform.system() == "Windows" and platform.release() != "2"
 
+
 if TYPE_CHECKING:
     from toolkit.stable_diffusion_model import StableDiffusion
-    
 
-image_extensions = ['.jpg', '.jpeg', '.png', '.webp']
-video_extensions = ['.mp4', '.avi', '.mov', '.webm', '.mkv', '.wmv', '.m4v', '.flv']
+
+image_extensions = [".jpg", ".jpeg", ".png", ".webp"]
+video_extensions = [".mp4", ".avi", ".mov", ".webm", ".mkv", ".wmv", ".m4v", ".flv"]
 
 
 class RescaleTransform:
@@ -74,26 +83,32 @@ class NormalizeSD15Transform:
         )(image)
 
 
-
 class ImageDataset(Dataset, CaptionMixin):
     def __init__(self, config):
         self.config = config
-        self.name = self.get_config('name', 'dataset')
-        self.path = self.get_config('path', required=True)
-        self.scale = self.get_config('scale', 1)
-        self.random_scale = self.get_config('random_scale', False)
-        self.include_prompt = self.get_config('include_prompt', False)
-        self.default_prompt = self.get_config('default_prompt', '')
+        self.name = self.get_config("name", "dataset")
+        self.path = self.get_config("path", required=True)
+        self.scale = self.get_config("scale", 1)
+        self.random_scale = self.get_config("random_scale", False)
+        self.include_prompt = self.get_config("include_prompt", False)
+        self.default_prompt = self.get_config("default_prompt", "")
         if self.include_prompt:
-            self.caption_type = self.get_config('caption_ext', 'txt')
+            self.caption_type = self.get_config("caption_ext", "txt")
         else:
             self.caption_type = None
         # we always random crop if random scale is enabled
-        self.random_crop = self.random_scale if self.random_scale else self.get_config('random_crop', False)
+        self.random_crop = (
+            self.random_scale
+            if self.random_scale
+            else self.get_config("random_crop", False)
+        )
 
-        self.resolution = self.get_config('resolution', 256)
-        self.file_list = [os.path.join(self.path, file) for file in os.listdir(self.path) if
-                          file.lower().endswith(('.jpg', '.jpeg', '.png', '.webp'))]
+        self.resolution = self.get_config("resolution", 256)
+        self.file_list = [
+            os.path.join(self.path, file)
+            for file in os.listdir(self.path)
+            if file.lower().endswith((".jpg", ".jpeg", ".png", ".webp"))
+        ]
 
         # this might take a while
         print_acc(f"  -  Preprocessing image dimensions")
@@ -112,10 +127,12 @@ class ImageDataset(Dataset, CaptionMixin):
         print_acc(f"  -  Found {bad_count} images that are too small")
         assert len(self.file_list) > 0, f"no images found in {self.path}"
 
-        self.transform = transforms.Compose([
-            transforms.ToTensor(),
-            RescaleTransform(),
-        ])
+        self.transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                RescaleTransform(),
+            ]
+        )
 
     def get_config(self, key, default=None, required=False):
         if key in self.config:
@@ -132,22 +149,28 @@ class ImageDataset(Dataset, CaptionMixin):
     def __getitem__(self, index):
         img_path = self.file_list[index]
         try:
-            img = exif_transpose(Image.open(img_path)).convert('RGB')
+            img = exif_transpose(Image.open(img_path)).convert("RGB")
         except Exception as e:
             print_acc(f"Error opening image: {img_path}")
             print_acc(e)
             # make a noise image if we can't open it
-            img = Image.fromarray(np.random.randint(0, 255, (1024, 1024, 3), dtype=np.uint8))
+            img = Image.fromarray(
+                np.random.randint(0, 255, (1024, 1024, 3), dtype=np.uint8)
+            )
 
         # Downscale the source image first
-        img = img.resize((int(img.size[0] * self.scale), int(img.size[1] * self.scale)), Image.BICUBIC)
+        img = img.resize(
+            (int(img.size[0] * self.scale), int(img.size[1] * self.scale)),
+            Image.BICUBIC,
+        )
         min_img_size = min(img.size)
 
         if self.random_crop:
             if self.random_scale and min_img_size > self.resolution:
                 if min_img_size < self.resolution:
                     print_acc(
-                        f"Unexpected values: min_img_size={min_img_size}, self.resolution={self.resolution}, image file={img_path}")
+                        f"Unexpected values: min_img_size={min_img_size}, self.resolution={self.resolution}, image file={img_path}"
+                    )
                     scale_size = self.resolution
                 else:
                     scale_size = random.randint(self.resolution, int(min_img_size))
@@ -169,19 +192,18 @@ class ImageDataset(Dataset, CaptionMixin):
             return img
 
 
-
-
-
 class AugmentedImageDataset(ImageDataset):
     def __init__(self, config):
         super().__init__(config)
-        self.augmentations = self.get_config('augmentations', [])
+        self.augmentations = self.get_config("augmentations", [])
         self.augmentations = [Augments(**aug) for aug in self.augmentations]
 
         augmentation_list = []
         for aug in self.augmentations:
             # make sure method name is valid
-            assert hasattr(A, aug.method_name), f"invalid augmentation method: {aug.method_name}"
+            assert hasattr(
+                A, aug.method_name
+            ), f"invalid augmentation method: {aug.method_name}"
             # get the method
             method = getattr(A, aug.method_name)
             # add the method to the list
@@ -217,31 +239,48 @@ class PairedImageDataset(Dataset):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.size = self.get_config('size', 512)
-        self.path = self.get_config('path', None)
-        self.pos_folder = self.get_config('pos_folder', None)
-        self.neg_folder = self.get_config('neg_folder', None)
+        self.size = self.get_config("size", 512)
+        self.path = self.get_config("path", None)
+        self.pos_folder = self.get_config("pos_folder", None)
+        self.neg_folder = self.get_config("neg_folder", None)
 
-        self.default_prompt = self.get_config('default_prompt', '')
-        self.network_weight = self.get_config('network_weight', 1.0)
-        self.pos_weight = self.get_config('pos_weight', self.network_weight)
-        self.neg_weight = self.get_config('neg_weight', self.network_weight)
+        self.default_prompt = self.get_config("default_prompt", "")
+        self.network_weight = self.get_config("network_weight", 1.0)
+        self.pos_weight = self.get_config("pos_weight", self.network_weight)
+        self.neg_weight = self.get_config("neg_weight", self.network_weight)
 
-        supported_exts = ('.jpg', '.jpeg', '.png', '.webp', '.JPEG', '.JPG', '.PNG', '.WEBP')
+        supported_exts = (
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".webp",
+            ".JPEG",
+            ".JPG",
+            ".PNG",
+            ".WEBP",
+        )
 
         if self.pos_folder is not None and self.neg_folder is not None:
             # find matching files
-            self.pos_file_list = [os.path.join(self.pos_folder, file) for file in os.listdir(self.pos_folder) if
-                                  file.lower().endswith(supported_exts)]
-            self.neg_file_list = [os.path.join(self.neg_folder, file) for file in os.listdir(self.neg_folder) if
-                                  file.lower().endswith(supported_exts)]
+            self.pos_file_list = [
+                os.path.join(self.pos_folder, file)
+                for file in os.listdir(self.pos_folder)
+                if file.lower().endswith(supported_exts)
+            ]
+            self.neg_file_list = [
+                os.path.join(self.neg_folder, file)
+                for file in os.listdir(self.neg_folder)
+                if file.lower().endswith(supported_exts)
+            ]
 
             matched_files = []
             for pos_file in self.pos_file_list:
                 pos_file_no_ext = os.path.splitext(pos_file)[0]
                 for neg_file in self.neg_file_list:
                     neg_file_no_ext = os.path.splitext(neg_file)[0]
-                    if os.path.basename(pos_file_no_ext) == os.path.basename(neg_file_no_ext):
+                    if os.path.basename(pos_file_no_ext) == os.path.basename(
+                        neg_file_no_ext
+                    ):
                         matched_files.append((neg_file, pos_file))
                         break
 
@@ -251,14 +290,19 @@ class PairedImageDataset(Dataset):
             self.file_list = matched_files
             print_acc(f"  -  Found {len(self.file_list)} matching pairs")
         else:
-            self.file_list = [os.path.join(self.path, file) for file in os.listdir(self.path) if
-                              file.lower().endswith(supported_exts)]
+            self.file_list = [
+                os.path.join(self.path, file)
+                for file in os.listdir(self.path)
+                if file.lower().endswith(supported_exts)
+            ]
             print_acc(f"  -  Found {len(self.file_list)} images")
 
-        self.transform = transforms.Compose([
-            transforms.ToTensor(),
-            RescaleTransform(),
-        ])
+        self.transform = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                RescaleTransform(),
+            ]
+        )
 
     def get_all_prompts(self):
         prompts = []
@@ -286,28 +330,28 @@ class PairedImageDataset(Dataset):
         if isinstance(img_path_or_tuple, tuple):
             # check if either has a prompt file
             path_no_ext = os.path.splitext(img_path_or_tuple[0])[0]
-            prompt_path = path_no_ext + '.txt'
+            prompt_path = path_no_ext + ".txt"
             if not os.path.exists(prompt_path):
                 path_no_ext = os.path.splitext(img_path_or_tuple[1])[0]
-                prompt_path = path_no_ext + '.txt'
+                prompt_path = path_no_ext + ".txt"
         else:
             img_path = img_path_or_tuple
             # see if prompt file exists
             path_no_ext = os.path.splitext(img_path)[0]
-            prompt_path = path_no_ext + '.txt'
+            prompt_path = path_no_ext + ".txt"
 
         if os.path.exists(prompt_path):
-            with open(prompt_path, 'r', encoding='utf-8') as f:
+            with open(prompt_path, "r", encoding="utf-8") as f:
                 prompt = f.read()
                 # remove any newlines
-                prompt = prompt.replace('\n', ', ')
+                prompt = prompt.replace("\n", ", ")
                 # remove new lines for all operating systems
-                prompt = prompt.replace('\r', ', ')
-                prompt_split = prompt.split(',')
+                prompt = prompt.replace("\r", ", ")
+                prompt_split = prompt.split(",")
                 # remove empty strings
                 prompt_split = [p.strip() for p in prompt_split if p.strip()]
                 # join back together
-                prompt = ', '.join(prompt_split)
+                prompt = ", ".join(prompt_split)
         else:
             prompt = self.default_prompt
         return prompt
@@ -317,9 +361,9 @@ class PairedImageDataset(Dataset):
         if isinstance(img_path_or_tuple, tuple):
             # load both images
             img_path = img_path_or_tuple[0]
-            img1 = exif_transpose(Image.open(img_path)).convert('RGB')
+            img1 = exif_transpose(Image.open(img_path)).convert("RGB")
             img_path = img_path_or_tuple[1]
-            img2 = exif_transpose(Image.open(img_path)).convert('RGB')
+            img2 = exif_transpose(Image.open(img_path)).convert("RGB")
 
             # always use # 2 (pos)
             bucket_resolution = get_bucket_for_image_size(
@@ -330,16 +374,24 @@ class PairedImageDataset(Dataset):
             )
 
             # images will be same base dimension, but may be trimmed. We need to shrink and then central crop
-            if bucket_resolution['width'] > bucket_resolution['height']:
+            if bucket_resolution["width"] > bucket_resolution["height"]:
                 img1_scale_to_height = bucket_resolution["height"]
-                img1_scale_to_width = int(img1.width * (bucket_resolution["height"] / img1.height))
+                img1_scale_to_width = int(
+                    img1.width * (bucket_resolution["height"] / img1.height)
+                )
                 img2_scale_to_height = bucket_resolution["height"]
-                img2_scale_to_width = int(img2.width * (bucket_resolution["height"] / img2.height))
+                img2_scale_to_width = int(
+                    img2.width * (bucket_resolution["height"] / img2.height)
+                )
             else:
                 img1_scale_to_width = bucket_resolution["width"]
-                img1_scale_to_height = int(img1.height * (bucket_resolution["width"] / img1.width))
+                img1_scale_to_height = int(
+                    img1.height * (bucket_resolution["width"] / img1.width)
+                )
                 img2_scale_to_width = bucket_resolution["width"]
-                img2_scale_to_height = int(img2.height * (bucket_resolution["width"] / img2.width))
+                img2_scale_to_height = int(
+                    img2.height * (bucket_resolution["width"] / img2.width)
+                )
 
             img1_crop_height = bucket_resolution["height"]
             img1_crop_width = bucket_resolution["width"]
@@ -347,18 +399,24 @@ class PairedImageDataset(Dataset):
             img2_crop_width = bucket_resolution["width"]
 
             # scale then center crop images
-            img1 = img1.resize((img1_scale_to_width, img1_scale_to_height), Image.BICUBIC)
+            img1 = img1.resize(
+                (img1_scale_to_width, img1_scale_to_height), Image.BICUBIC
+            )
             img1 = transforms.CenterCrop((img1_crop_height, img1_crop_width))(img1)
-            img2 = img2.resize((img2_scale_to_width, img2_scale_to_height), Image.BICUBIC)
+            img2 = img2.resize(
+                (img2_scale_to_width, img2_scale_to_height), Image.BICUBIC
+            )
             img2 = transforms.CenterCrop((img2_crop_height, img2_crop_width))(img2)
 
             # combine them side by side
-            img = Image.new('RGB', (img1.width + img2.width, max(img1.height, img2.height)))
+            img = Image.new(
+                "RGB", (img1.width + img2.width, max(img1.height, img2.height))
+            )
             img.paste(img1, (0, 0))
             img.paste(img2, (img1.width, 0))
         else:
             img_path = img_path_or_tuple
-            img = exif_transpose(Image.open(img_path)).convert('RGB')
+            img = exif_transpose(Image.open(img_path)).convert("RGB")
             height = self.size
             # determine width to keep aspect ratio
             width = int(img.size[0] * height / img.size[1])
@@ -372,13 +430,20 @@ class PairedImageDataset(Dataset):
         return img, prompt, (self.neg_weight, self.pos_weight)
 
 
-class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin, BucketsMixin, CaptionMixin, Dataset):
+class AiToolkitDataset(
+    LatentCachingMixin,
+    ControlCachingMixin,
+    CLIPCachingMixin,
+    BucketsMixin,
+    CaptionMixin,
+    Dataset,
+):
 
     def __init__(
-            self,
-            dataset_config: 'DatasetConfig',
-            batch_size=1,
-            sd: 'StableDiffusion' = None,
+        self,
+        dataset_config: "DatasetConfig",
+        batch_size=1,
+        sd: "StableDiffusion" = None,
     ):
         self.dataset_config = dataset_config
         # update bucket divisibility
@@ -390,7 +455,9 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
         if self.dataset_path is None:
             self.dataset_path = folder_path
 
-        self.is_caching_latents = dataset_config.cache_latents or dataset_config.cache_latents_to_disk
+        self.is_caching_latents = (
+            dataset_config.cache_latents or dataset_config.cache_latents_to_disk
+        )
         self.is_caching_latents_to_memory = dataset_config.cache_latents
         self.is_caching_latents_to_disk = dataset_config.cache_latents_to_disk
         self.is_caching_clip_vision_to_disk = dataset_config.cache_clip_vision_to_disk
@@ -408,10 +475,12 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
         self.scale = dataset_config.scale
         self.batch_size = batch_size
         # we always random crop if random scale is enabled
-        self.random_crop = self.random_scale if self.random_scale else dataset_config.random_crop
+        self.random_crop = (
+            self.random_scale if self.random_scale else dataset_config.random_crop
+        )
         self.resolution = dataset_config.resolution
         self.caption_dict = None
-        self.file_list: List['FileItemDTO'] = []
+        self.file_list: List["FileItemDTO"] = []
 
         # check if dataset_path is a folder or json
         if os.path.isdir(self.dataset_path):
@@ -419,16 +488,25 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
             if self.is_video:
                 # only look for videos
                 extensions = video_extensions
-            file_list = [os.path.join(root, file) for root, _, files in os.walk(self.dataset_path) for file in files if file.lower().endswith(tuple(extensions))]
+            file_list = [
+                os.path.join(root, file)
+                for root, _, files in os.walk(self.dataset_path)
+                for file in files
+                if file.lower().endswith(tuple(extensions))
+            ]
         else:
             # assume json
-            with open(self.dataset_path, 'r') as f:
+            with open(self.dataset_path, "r") as f:
                 self.caption_dict = json.load(f)
                 # keys are file paths
                 file_list = list(self.caption_dict.keys())
-                
+
         # remove items in the _controls_ folder
-        file_list = [x for x in file_list if not os.path.basename(os.path.dirname(x)) == "_controls"]
+        file_list = [
+            x
+            for x in file_list
+            if not os.path.basename(os.path.dirname(x)) == "_controls"
+        ]
 
         if self.dataset_config.num_repeats > 1:
             # repeat the list
@@ -440,16 +518,20 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
             else:
                 NormalizeMethod = NormalizeSD15Transform
 
-            self.transform = transforms.Compose([
-                transforms.ToTensor(),
-                RescaleTransform(),
-                NormalizeMethod(),
-            ])
+            self.transform = transforms.Compose(
+                [
+                    transforms.ToTensor(),
+                    RescaleTransform(),
+                    NormalizeMethod(),
+                ]
+            )
         else:
-            self.transform = transforms.Compose([
-                transforms.ToTensor(),
-                RescaleTransform(),
-            ])
+            self.transform = transforms.Compose(
+                [
+                    transforms.ToTensor(),
+                    RescaleTransform(),
+                ]
+            )
 
         # this might take a while
         print_acc(f"Dataset: {self.dataset_path}")
@@ -460,15 +542,18 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
         dataset_folder = self.dataset_path
         if not os.path.isdir(self.dataset_path):
             dataset_folder = os.path.dirname(dataset_folder)
-        
-        dataset_size_file = os.path.join(dataset_folder, '.aitk_size.json')
+
+        dataset_size_file = os.path.join(dataset_folder, ".aitk_size.json")
         dataloader_version = "0.1.2"
         if os.path.exists(dataset_size_file):
             try:
-                with open(dataset_size_file, 'r') as f:
+                with open(dataset_size_file, "r") as f:
                     self.size_database = json.load(f)
-                
-                if "__version__" not in self.size_database or self.size_database["__version__"] != dataloader_version:
+
+                if (
+                    "__version__" not in self.size_database
+                    or self.size_database["__version__"] != dataloader_version
+                ):
                     print_acc("Upgrading size database to new version")
                     # old version, delete and recreate
                     self.size_database = {}
@@ -478,7 +563,7 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
                 self.size_database = {}
         else:
             self.size_database = {}
-        
+
         self.size_database["__version__"] = dataloader_version
 
         bad_count = 0
@@ -503,9 +588,9 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
                 bad_count += 1
 
         # save the size database
-        with open(dataset_size_file, 'w') as f:
+        with open(dataset_size_file, "w") as f:
             json.dump(self.size_database, f)
-        
+
         if self.is_video:
             print_acc(f"  -  Found {len(self.file_list)} videos")
             assert len(self.file_list) > 0, f"no videos found in {self.dataset_path}"
@@ -567,8 +652,8 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
             return len(self.batch_indices)
         return len(self.file_list)
 
-    def _get_single_item(self, index) -> 'FileItemDTO':
-        file_item: 'FileItemDTO' = copy.deepcopy(self.file_list[index])
+    def _get_single_item(self, index) -> "FileItemDTO":
+        file_item: "FileItemDTO" = copy.deepcopy(self.file_list[index])
         file_item.load_and_process_image(self.transform)
         file_item.load_caption(self.caption_dict)
         return file_item
@@ -589,10 +674,11 @@ class AiToolkitDataset(LatentCachingMixin, ControlCachingMixin, CLIPCachingMixin
 
 
 def get_dataloader_from_datasets(
-        dataset_options,
-        batch_size=1,
-        sd: 'StableDiffusion' = None,
-) -> DataLoader:
+    dataset_options,
+    batch_size=1,
+    sd: "StableDiffusion" = None,
+    validation_every=None,
+) -> List[DataLoader]:
     if dataset_options is None or len(dataset_options) == 0:
         return None
 
@@ -613,7 +699,7 @@ def get_dataloader_from_datasets(
 
     for config in dataset_config_list:
 
-        if config.type == 'image':
+        if config.type == "image":
             dataset = AiToolkitDataset(config, batch_size=batch_size, sd=sd)
             datasets.append(dataset)
             if config.buckets:
@@ -625,48 +711,79 @@ def get_dataloader_from_datasets(
 
     concatenated_dataset = ConcatDataset(datasets)
 
+    train_size = int(
+        len(concatenated_dataset) * dataset_config_list[0].validation_percent
+    )
+    validation_size = len(concatenated_dataset) - train_size
+    train_dataset, validation_dataset = random_split(
+        concatenated_dataset,
+        [train_size, validation_size],
+        generator=torch.Generator().manual_seed(42),
+    )
+
     # todo build scheduler that can get buckets from all datasets that match
     # todo and evenly distribute reg images
 
-    def dto_collation(batch: List['FileItemDTO']):
+    def dto_collation(batch: List["FileItemDTO"]):
         # create DTO batch
-        batch = DataLoaderBatchDTO(
-            file_items=batch
-        )
+        batch = DataLoaderBatchDTO(file_items=batch)
         return batch
 
     # check if is caching latents
 
     dataloader_kwargs = {}
-    
-    if is_native_windows():
-        dataloader_kwargs['num_workers'] = 0
-    else:
-        dataloader_kwargs['num_workers'] = dataset_config_list[0].num_workers
-        dataloader_kwargs['prefetch_factor'] = dataset_config_list[0].prefetch_factor
 
+    if is_native_windows():
+        dataloader_kwargs["num_workers"] = 0
+    else:
+        dataloader_kwargs["num_workers"] = dataset_config_list[0].num_workers
+        dataloader_kwargs["prefetch_factor"] = dataset_config_list[0].prefetch_factor
+
+    result_loaders = []
     if has_buckets:
         # make sure they all have buckets
         for dataset in datasets:
-            assert dataset.dataset_config.buckets, f"buckets not found on dataset {dataset.dataset_config.folder_path}, you either need all buckets or none"
-
-        data_loader = DataLoader(
-            concatenated_dataset,
+            assert (
+                dataset.dataset_config.buckets
+            ), f"buckets not found on dataset {dataset.dataset_config.folder_path}, you either need all buckets or none"
+        train_loader = DataLoader(
+            train_dataset,
             batch_size=None,  # we batch in the datasets for now
             drop_last=False,
             shuffle=True,
             collate_fn=dto_collation,  # Use the custom collate function
-            **dataloader_kwargs
+            **dataloader_kwargs,
         )
+        result_loaders.append(train_loader)
+        if validation_every is not None:
+            validation_loader = DataLoader(
+                validation_dataset,
+                batch_size=1,  # we batch in the datasets for now
+                drop_last=False,
+                shuffle=False,
+                collate_fn=dto_collation,  # Use the custom collate function
+                **dataloader_kwargs,
+            )
+            result_loaders.append(validation_loader)
     else:
         data_loader = DataLoader(
-            concatenated_dataset,
+            train_dataset,
             batch_size=batch_size,
             shuffle=True,
             collate_fn=dto_collation,
-            **dataloader_kwargs
+            **dataloader_kwargs,
         )
-    return data_loader
+        result_loaders.append(data_loader)
+        if validation_every is not None:
+            validation_loader = DataLoader(
+                validation_dataset,
+                batch_size=1,
+                shuffle=False,
+                collate_fn=dto_collation,
+                **dataloader_kwargs,
+            )
+            result_loaders.append(validation_loader)
+    return result_loaders
 
 
 def trigger_dataloader_setup_epoch(dataloader: DataLoader):
@@ -674,36 +791,37 @@ def trigger_dataloader_setup_epoch(dataloader: DataLoader):
     dataloader.len = None
     if isinstance(dataloader.dataset, list):
         for dataset in dataloader.dataset:
-            if hasattr(dataset, 'datasets'):
+            if hasattr(dataset, "datasets"):
                 for sub_dataset in dataset.datasets:
-                    if hasattr(sub_dataset, 'setup_epoch'):
+                    if hasattr(sub_dataset, "setup_epoch"):
                         sub_dataset.setup_epoch()
                         sub_dataset.len = None
-            elif hasattr(dataset, 'setup_epoch'):
+            elif hasattr(dataset, "setup_epoch"):
                 dataset.setup_epoch()
                 dataset.len = None
-    elif hasattr(dataloader.dataset, 'setup_epoch'):
+    elif hasattr(dataloader.dataset, "setup_epoch"):
         dataloader.dataset.setup_epoch()
         dataloader.dataset.len = None
-    elif hasattr(dataloader.dataset, 'datasets'):
+    elif hasattr(dataloader.dataset, "datasets"):
         dataloader.dataset.len = None
         for sub_dataset in dataloader.dataset.datasets:
-            if hasattr(sub_dataset, 'setup_epoch'):
+            if hasattr(sub_dataset, "setup_epoch"):
                 sub_dataset.setup_epoch()
                 sub_dataset.len = None
+
 
 def get_dataloader_datasets(dataloader: DataLoader):
     # hacky but needed because of different types of datasets and dataloaders
     if isinstance(dataloader.dataset, list):
         datasets = []
         for dataset in dataloader.dataset:
-            if hasattr(dataset, 'datasets'):
+            if hasattr(dataset, "datasets"):
                 for sub_dataset in dataset.datasets:
                     datasets.append(sub_dataset)
             else:
                 datasets.append(dataset)
         return datasets
-    elif hasattr(dataloader.dataset, 'datasets'):
+    elif hasattr(dataloader.dataset, "datasets"):
         return dataloader.dataset.datasets
     else:
         return [dataloader.dataset]


### PR DESCRIPTION
## Summary
- add validation data loader options
- support random validation splits
- return train and validation loaders from `get_dataloader_from_datasets`
- run validation loop every N steps
- adjust advanced generator modules and tests for updated API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b45f3888323ae14c2540b1fe7e4