### PR TITLE
Revert pipeline changes

### DIFF
--- a/extensions_built_in/flex2/flex2.py
+++ b/extensions_built_in/flex2/flex2.py
@@ -21,7 +21,6 @@ from toolkit.util.quantize import quantize, get_qtype
 from transformers import T5TokenizerFast, T5EncoderModel, CLIPTextModel, CLIPTokenizer
 from .pipeline import Flex2Pipeline
 from einops import rearrange, repeat
-import math
 import random
 import torch.nn.functional as F
 
@@ -265,21 +264,16 @@ class Flex2(BaseModel):
     ):
         with torch.no_grad():
             bs, c, h, w = latent_model_input.shape
-            patch = Flex2Pipeline._calc_patch_size(
-                h, w, self.unet_unwrapped.config.in_channels
-            )
-            while patch > 1 and (h % patch != 0 or w % patch != 0):
-                patch -= 1
             latent_model_input_packed = rearrange(
                 latent_model_input,
                 "b c (h ph) (w pw) -> b (h w) (c ph pw)",
-                ph=patch,
-                pw=patch
+                ph=2,
+                pw=2
             )
 
-            img_ids = torch.zeros(h // patch, w // patch, 3)
-            img_ids[..., 1] = img_ids[..., 1] + torch.arange(h // patch)[:, None]
-            img_ids[..., 2] = img_ids[..., 2] + torch.arange(w // patch)[None, :]
+            img_ids = torch.zeros(h // 2, w // 2, 3)
+            img_ids[..., 1] = img_ids[..., 1] + torch.arange(h // 2)[:, None]
+            img_ids[..., 2] = img_ids[..., 2] + torch.arange(w // 2)[None, :]
             img_ids = repeat(img_ids, "h w c -> b (h w) c",
                              b=bs).to(self.device_torch)
 
@@ -329,11 +323,11 @@ class Flex2(BaseModel):
         noise_pred = rearrange(
             noise_pred,
             "b (h w) (c ph pw) -> b c (h ph) (w pw)",
-            h=latent_model_input.shape[2] // patch,
-            w=latent_model_input.shape[3] // patch,
-            ph=patch,
-            pw=patch,
-            c=self.vae.config.latent_channels,
+            h=latent_model_input.shape[2] // 2,
+            w=latent_model_input.shape[3] // 2,
+            ph=2,
+            pw=2,
+            c=self.vae.config.latent_channels
         )
 
         if bypass_guidance_embedding:

--- a/extensions_built_in/flex2/pipeline.py
+++ b/extensions_built_in/flex2/pipeline.py
@@ -11,9 +11,6 @@ from diffusers.pipelines.flux.pipeline_output import FluxPipelineOutput
 from diffusers.pipelines.flux.pipeline_flux import calculate_shift, retrieve_timesteps, XLA_AVAILABLE
 
 
-import math
-
-
 class Flex2Pipeline(FluxControlPipeline):
     def __init__(
         self,
@@ -233,7 +230,6 @@ class Flex2Pipeline(FluxControlPipeline):
                     num_control_channels,
                     height_control_image,
                     width_control_image,
-                    self.transformer.config.in_channels,
                 )
 
         latents, latent_image_ids = self.prepare_latents(
@@ -336,13 +332,7 @@ class Flex2Pipeline(FluxControlPipeline):
         if output_type == "latent":
             image = latents
         else:
-            latents = self._unpack_latents(
-                latents,
-                height,
-                width,
-                self.vae_scale_factor,
-                self.transformer.config.in_channels,
-            )
+            latents = self._unpack_latents(latents, height, width, self.vae_scale_factor)
             latents = (latents / self.vae.config.scaling_factor) + self.vae.config.shift_factor
             image = self.vae.decode(latents, return_dict=False)[0]
             image = self.image_processor.postprocess(image, output_type=output_type)
@@ -354,40 +344,5 @@ class Flex2Pipeline(FluxControlPipeline):
             return (image,)
 
         return FluxPipelineOutput(images=image)
-
-    @staticmethod
-    def _calc_patch_size(height: int, width: int, patch_count: int) -> int:
-        """Calculate patch size so that number of patches matches patch_count."""
-        patch_area = (height * width) // patch_count
-        patch_size = int(math.sqrt(patch_area))
-        patch_size = max(patch_size, 1)
-        return patch_size
-
-    @staticmethod
-    def _pack_latents(latents, batch_size, num_channels_latents, height, width, patch_count=None):
-        if patch_count is None:
-            patch = 2
-        else:
-            patch = Flex2Pipeline._calc_patch_size(height, width, patch_count)
-        latents = latents.view(batch_size, num_channels_latents, height // patch, patch, width // patch, patch)
-        latents = latents.permute(0, 2, 4, 1, 3, 5)
-        latents = latents.reshape(batch_size, (height // patch) * (width // patch), num_channels_latents * patch * patch)
-        return latents
-
-    @staticmethod
-    def _unpack_latents(latents, height, width, vae_scale_factor, patch_count=None):
-        batch_size, num_patches, channels = latents.shape
-        height = int(height)
-        width = int(width)
-        if patch_count is None:
-            patch = 2
-        else:
-            patch = Flex2Pipeline._calc_patch_size(height, width, patch_count)
-        height = patch * (height // (vae_scale_factor * patch))
-        width = patch * (width // (vae_scale_factor * patch))
-        latents = latents.view(batch_size, height // patch, width // patch, channels // (patch * patch), patch, patch)
-        latents = latents.permute(0, 3, 1, 4, 2, 5)
-        latents = latents.reshape(batch_size, channels // (patch * patch), height, width)
-        return latents
 
     


### PR DESCRIPTION
## Summary
- revert Flex2 pipeline to earlier revision
- restore flex2 model operations for fixed patch size

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, tqdm, PIL, torch)*

------
https://chatgpt.com/codex/tasks/task_e_684c2835d9908323a58733f92d4a0fb4