### PR TITLE
Fix patch size handling in flux2

### DIFF
--- a/extensions_built_in/flex2/flex2.py
+++ b/extensions_built_in/flex2/flex2.py
@@ -21,6 +21,7 @@ from toolkit.util.quantize import quantize, get_qtype
 from transformers import T5TokenizerFast, T5EncoderModel, CLIPTextModel, CLIPTokenizer
 from .pipeline import Flex2Pipeline
 from einops import rearrange, repeat
+import math
 import random
 import torch.nn.functional as F
 
@@ -265,8 +266,12 @@ class Flex2(BaseModel):
         with torch.no_grad():
             bs, c, h, w = latent_model_input.shape
 
-            ph = 2
-            pw = 2
+            patch = int(math.sqrt(self.unet.x_embedder.in_features / c))
+            patch = max(patch, 1)
+            while patch > 1 and (h % patch != 0 or w % patch != 0):
+                patch -= 1
+            ph = patch
+            pw = patch
 
             pad_h = (ph - h % ph) % ph
             pad_w = (pw - w % pw) % pw


### PR DESCRIPTION
## Summary
- adjust patch size logic in `flex2` to compute dynamically from model dims

## Testing
- `pytest -q` *(fails: torchvision missing operators, transformers imports)*

------
https://chatgpt.com/codex/tasks/task_e_684c35bf2604832389e1c935b36f402d