### PR TITLE
Fix patch size calculation

### DIFF
--- a/extensions_built_in/flex2/flex2.py
+++ b/extensions_built_in/flex2/flex2.py
@@ -266,7 +266,8 @@ class Flex2(BaseModel):
         with torch.no_grad():
             bs, c, h, w = latent_model_input.shape
 
-            patch = int(math.sqrt(self.unet.x_embedder.in_features / c))
+            embed_in = max(self.unet.x_embedder.in_features - 1, 1)
+            patch = int(math.sqrt(embed_in / c))
             patch = max(patch, 1)
             while patch > 1 and (h % patch != 0 or w % patch != 0):
                 patch -= 1


### PR DESCRIPTION
## Summary
- fix patch size calculation to account for extra channel

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'tqdm', 'PIL', 'safetensors')*

------
https://chatgpt.com/codex/tasks/task_e_684c3b319c388323b025706167ec981a